### PR TITLE
New filter API

### DIFF
--- a/Api/Filter/FilterInterface.php
+++ b/Api/Filter/FilterInterface.php
@@ -18,10 +18,4 @@ namespace Dunglas\ApiBundle\Api\Filter;
  */
 interface FilterInterface
 {
-    /**
-     * Gets filter name.
-     *
-     * @return string
-     */
-    public function getName();
 }

--- a/Controller/ResourceController.php
+++ b/Controller/ResourceController.php
@@ -118,31 +118,11 @@ class ResourceController extends Controller
      * @param ResourceInterface $resource
      * @param Request           $request
      *
-     * @return PaginatorInterface
+     * @return PaginatorInterface|array|\Traversable
      */
     protected function getCollectionData(ResourceInterface $resource, Request $request)
     {
-        $page = (int) $request->get($this->container->getParameter('api.collection.pagination.page_parameter_name'), 1);
-
-        $defaultItemsPerPage = $this->container->getParameter('api.collection.pagination.items_per_page.number');
-
-        $itemsPerPage = $defaultItemsPerPage;
-
-        if ($this->container->getParameter('api.collection.pagination.items_per_page.enable_client_request')) {
-            $parameterName = $this->container->getParameter('api.collection.pagination.items_per_page.parameter_name');
-            $itemsPerPage = $request->get($parameterName, $defaultItemsPerPage);
-        }
-
-        $defaultOrder = $this->container->getParameter('api.collection.order');
-        $order = $defaultOrder ? ['id' => $defaultOrder] : [];
-
-        return $this->get('api.data_provider')->getCollection(
-            $resource,
-            $request->query->getIterator()->getArrayCopy(),
-            $order,
-            $page,
-            $itemsPerPage
-        );
+        return $this->get('api.data_provider')->getCollection($resource, $request);
     }
 
     /**

--- a/Doctrine/Orm/FilterInterface.php
+++ b/Doctrine/Orm/FilterInterface.php
@@ -14,6 +14,7 @@ namespace Dunglas\ApiBundle\Doctrine\Orm;
 use Doctrine\ORM\QueryBuilder;
 use Dunglas\ApiBundle\Api\Filter\FilterInterface as BaseFilterInterface;
 use Dunglas\ApiBundle\Api\ResourceInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Doctrine ORM filter interface.
@@ -27,7 +28,7 @@ interface FilterInterface extends BaseFilterInterface
      *
      * @param ResourceInterface $resource
      * @param QueryBuilder      $queryBuilder
-     * @param string            $value
+     * @param Request           $request
      */
-    public function apply(ResourceInterface $resource, QueryBuilder $queryBuilder, $value);
+    public function apply(ResourceInterface $resource, QueryBuilder $queryBuilder, Request $request);
 }

--- a/Model/DataProviderChain.php
+++ b/Model/DataProviderChain.php
@@ -12,6 +12,7 @@
 namespace Dunglas\ApiBundle\Model;
 
 use Dunglas\ApiBundle\Api\ResourceInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * A chain of data providers.
@@ -48,14 +49,15 @@ class DataProviderChain implements DataProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getCollection(ResourceInterface $resource, array $filters = [], array $order = [], $page = null, $itemsPerPage = null)
+    public function getCollection(ResourceInterface $resource, Request $request)
     {
         foreach ($this->dataProviders as $dataProvider) {
-            if ($dataProvider->supports($resource) &&
-                $result = $dataProvider->getCollection($resource, $filters, $order, $page, $itemsPerPage)) {
+            if ($dataProvider->supports($resource) && $result = $dataProvider->getCollection($resource, $request)) {
                 return $result;
             }
         }
+
+        return [];
     }
 
     /**

--- a/Model/DataProviderInterface.php
+++ b/Model/DataProviderInterface.php
@@ -12,6 +12,7 @@
 namespace Dunglas\ApiBundle\Model;
 
 use Dunglas\ApiBundle\Api\ResourceInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Data provider interface.
@@ -34,14 +35,12 @@ interface DataProviderInterface
     /**
      * Retrieves a collection.
      *
-     * @param array    $filters
-     * @param int|null $page
-     * @param int|null $itemsPerPage
-     * @param array    $order
+     * @param ResourceInterface $resource
+     * @param Request           $request
      *
      * @return PaginatorInterface|array|\Traversable
      */
-    public function getCollection(ResourceInterface $resource, array $filters = [], array $order = [], $page = null, $itemsPerPage = null);
+    public function getCollection(ResourceInterface $resource, Request $request);
 
     /**
      * Does this DataProvider supports the given resource.

--- a/README.md
+++ b/README.md
@@ -223,17 +223,13 @@ To allow filtering the list of offers:
 
 ```yaml
 services:
-    resource.offer.filter.id:
+    resource.offer.filter:
         parent:    "api.doctrine.orm.filter"
-        arguments: [ "id" ] # Filters on the id property, allow both numeric values and IRIs
-
-    resource.offer.filter.price:
-        parent:    "api.doctrine.orm.filter"
-        arguments: [ "price" ] # Extracts all collection elements with the exact given price
-
-    resource.offer.filter.name:
-        parent:    "api.doctrine.orm.filter"
-        arguments: [ "name", "partial" ] # Elements with given text in their name
+        arguments: [ {
+                        "id": "exact",    # Filters on the id property, allow both numeric values and IRIs
+                        "price": "exact", # Extracts all collection elements with the exact given price
+                        "name": "partial" # Elements with given text in their name
+                   } ]
 
     resource.offer:
         parent:    "api.resource"
@@ -241,13 +237,7 @@ services:
         calls:
             -      method:    "addFilter"
                    arguments:
-                       -      "@resource.offer.filter.id"
-            -      method:    "addFilter"
-                   arguments:
-                       -      "@resource.offer.filter.price"
-            -      method:    "addFilter"
-                   arguments:
-                       -      "@resource.offer.filter.name"
+                       -      "@resource.offer.filter"
         tags:      [ { name: "api.resource" } ]
 ```
 
@@ -260,9 +250,9 @@ It also possible to filter by relations:
 
 ```yaml
 services:
-    resource.offer.filter.product:
+    resource.offer.filter:
         parent:    "api.doctrine.orm.filter"
-        arguments: [ "product" ]
+        arguments: [ { "product": "exact" } ]
 
     resource.offer:
         parent:    "api.resource"
@@ -270,7 +260,7 @@ services:
         calls:
             -      method:    "addFilter"
                    arguments:
-                       -      "@resource.offer.filter.product"
+                       -      "@resource.offer.filter"
         tags:      [ { name: "api.resource" } ]
 ```
 
@@ -279,6 +269,24 @@ Try the following: `http://localhost:8000/api/offers?product=/api/products/12`
 Using a numeric ID will also work: `http://localhost:8000/api/offers?product=12`
 
 It will return all offers for the product having the JSON-LD identifier (`@id`) `http://localhost:8000/api/products/12`.
+
+The last possibility offered by the bundle is to enable filters on all properties exposed by the bundle by omitting the
+first argument of the filter:
+
+```yaml
+services:
+    resource.offer.filter:
+        parent:    "api.doctrine.orm.filter"
+
+    resource.offer:
+        parent:    "api.resource"
+        arguments: [ "AppBundle\Entity\Offer"] 
+        calls:
+            -      method:    "addFilter"
+                   arguments:
+                       -      "@resource.offer.filter"
+        tags:      [ { name: "api.resource" } ]
+```
 
 #### Creating custom filters
 

--- a/Resources/config/doctrine_orm.xml
+++ b/Resources/config/doctrine_orm.xml
@@ -18,6 +18,11 @@
 
         <service id="api.doctrine.orm.data_provider" class="Dunglas\ApiBundle\Doctrine\Orm\DataProvider" public="false">
             <argument type="service" id="doctrine" />
+            <argument>%api.collection.order%</argument>
+            <argument>%api.collection.pagination.page_parameter_name%</argument>
+            <argument>%api.collection.pagination.items_per_page.number%</argument>
+            <argument>%api.collection.pagination.items_per_page.enable_client_request%</argument>
+            <argument>%api.collection.pagination.items_per_page.parameter_name%</argument>
 
             <tag name="api.data_provider" />
         </service>

--- a/features/fixtures/TestApp/config/config.yml
+++ b/features/fixtures/TestApp/config/config.yml
@@ -33,13 +33,9 @@ dunglas_api:
                 enable_client_request: true
 
 services:
-    my_dummy_resource.filter.id:
+    my_dummy_resource.filter:
         parent:                     "api.doctrine.orm.filter"
-        arguments:                  [ "id" ]
-
-    my_dummy_resource.filter.name:
-        parent:                     "api.doctrine.orm.filter"
-        arguments:                  [ "name", "partial" ]
+        arguments:                  [ { "id": "exact", "name": "partial" } ]
 
     my_dummy_resource:
         parent:                      "api.resource"
@@ -47,10 +43,7 @@ services:
         calls:
                                      - method:    "addFilter"
                                        arguments:
-                                           -      "@my_dummy_resource.filter.id"
-                                     - method:    "addFilter"
-                                       arguments:
-                                           -      "@my_dummy_resource.filter.name"
+                                           -      "@my_dummy_resource.filter"
         tags:                        [ { name: "api.resource" } ]
 
     my_related_dummy_resource:


### PR DESCRIPTION
- Easier way to define multiple filters
- Possibility to enable filter on all fields of an entity

Finally I've abandoned the idea of using LoopBack style URLs because they are too ugly.
As `page` and `itemsPerPage` parameters are now configurable, conflicts can be easily avoided (ex: using an URLs like `?_page=2&_itemsPerPage=3`).

@theofidry @sroze What do you think about that? And what do you think about forwarding `$request` to `DataProvider` and `Filter` class? It's not very clean but it's powerful and useful when creating custom filters.