### PR TITLE
Hydra search support

### DIFF
--- a/Api/Filter/FilterInterface.php
+++ b/Api/Filter/FilterInterface.php
@@ -23,8 +23,10 @@ interface FilterInterface
     /**
      * Gets the description of this filter for the given resource.
      *
-     * Returns an array with the filter names as keys and array with the following data as values:
+     * Returns an array with the filter parameter names as keys and array with the following data as values:
+     *   - property: the property where the filter is applied
      *   - type: the type of the filter
+     *   - required: if this filter is required
      *   - strategy: the used strategy
      * The description can contain additional data specific to a filter.
      *

--- a/Doctrine/Orm/Filter.php
+++ b/Doctrine/Orm/Filter.php
@@ -81,7 +81,9 @@ class Filter implements FilterInterface
             $found = isset($this->properties[$fieldName]);
             if ($found || null === $this->properties) {
                 $description[$fieldName] = [
+                    'property' => $fieldName,
                     'type' => $metadata->getTypeOfField($fieldName),
+                    'required' => false,
                     'strategy' => $found ? $this->properties[$fieldName] : self::STRATEGY_EXACT,
                 ];
             }
@@ -89,7 +91,9 @@ class Filter implements FilterInterface
 
         foreach ($metadata->getAssociationNames() as $associationName) {
             $description[$associationName] = [
+                'property' => $associationName,
                 'type' => 'iri',
+                'required' => false,
                 'strategy' => self::STRATEGY_EXACT,
             ];
         }

--- a/Hydra/Serializer/CollectionNormalizer.php
+++ b/Hydra/Serializer/CollectionNormalizer.php
@@ -159,7 +159,6 @@ class CollectionNormalizer extends SerializerAwareNormalizer implements Normaliz
      */
     private function getPageUrl(array $parts, array $parameters, $page)
     {
-
         if (1. !== $page) {
             $parameters[$this->pageParameterName] = $page;
         }
@@ -202,7 +201,7 @@ class CollectionNormalizer extends SerializerAwareNormalizer implements Normaliz
 
         return [
             '@type' => 'hydra:IriTemplate',
-            'hydra:template' => sprintf('%s{?%s}', $parts['path'], join(',', $variables)),
+            'hydra:template' => sprintf('%s{?%s}', $parts['path'], implode(',', $variables)),
             'hydra:variableRepresentation' => 'BasicRepresentation',
             'hydra:mapping' => $mapping,
         ];

--- a/Hydra/Serializer/CollectionNormalizer.php
+++ b/Hydra/Serializer/CollectionNormalizer.php
@@ -12,6 +12,7 @@
 namespace Dunglas\ApiBundle\Hydra\Serializer;
 
 use Dunglas\ApiBundle\Api\ResourceCollectionInterface;
+use Dunglas\ApiBundle\Api\ResourceInterface;
 use Dunglas\ApiBundle\Api\ResourceResolver;
 use Dunglas\ApiBundle\JsonLd\ContextBuilder;
 use Dunglas\ApiBundle\Model\PaginatorInterface;
@@ -84,6 +85,7 @@ class CollectionNormalizer extends SerializerAwareNormalizer implements Normaliz
             }
         } else {
             $data['@id'] = $context['request_uri'];
+            list($parts, $parameters) = $this->parseRequestUri($context['request_uri']);
 
             if ($object instanceof PaginatorInterface) {
                 $data['@type'] = self::HYDRA_PAGED_COLLECTION;
@@ -93,17 +95,17 @@ class CollectionNormalizer extends SerializerAwareNormalizer implements Normaliz
 
                 if (1. !== $currentPage) {
                     $previousPage = $currentPage - 1.;
-                    $data['hydra:previousPage'] = $this->getPageUrl($context['request_uri'], $previousPage);
+                    $data['hydra:previousPage'] = $this->getPageUrl($parts, $parameters, $previousPage);
                 }
 
                 if ($currentPage !== $lastPage) {
-                    $data['hydra:nextPage'] = $this->getPageUrl($context['request_uri'], $currentPage + 1.);
+                    $data['hydra:nextPage'] = $this->getPageUrl($parts, $parameters, $currentPage + 1.);
                 }
 
                 $data['hydra:totalItems'] = $object->getTotalItems();
                 $data['hydra:itemsPerPage'] = $object->getItemsPerPage();
-                $data['hydra:firstPage'] = $this->getPageUrl($context['request_uri'], 1.);
-                $data['hydra:lastPage'] = $this->getPageUrl($context['request_uri'], $lastPage);
+                $data['hydra:firstPage'] = $this->getPageUrl($parts, $parameters, 1.);
+                $data['hydra:lastPage'] = $this->getPageUrl($parts, $parameters, $lastPage);
             } else {
                 $data['@type'] = self::HYDRA_COLLECTION;
             }
@@ -112,20 +114,24 @@ class CollectionNormalizer extends SerializerAwareNormalizer implements Normaliz
             foreach ($object as $obj) {
                 $data['hydra:member'][] = $this->serializer->normalize($obj, $format, $context);
             }
+
+            $filters = $resource->getFilters();
+            if (!empty($filters)) {
+                $data['hydra:search'] = $this->getSearch($resource, $parts, $filters);
+            }
         }
 
         return $data;
     }
 
     /**
-     * Gets a collection URL for the given page.
+     * Parse and standardize the request URI.
      *
      * @param string $requestUri
-     * @param float  $page
      *
-     * @return string
+     * @return array
      */
-    private function getPageUrl($requestUri, $page)
+    private function parseRequestUri($requestUri)
     {
         $parts = parse_url($requestUri);
 
@@ -138,6 +144,21 @@ class CollectionNormalizer extends SerializerAwareNormalizer implements Normaliz
                 unset($parameters[$this->pageParameterName]);
             }
         }
+
+        return [$parts, $parameters];
+    }
+
+    /**
+     * Gets a collection URL for the given page.
+     *
+     * @param array $parts
+     * @param array $parameters
+     * @param float $page
+     *
+     * @return string
+     */
+    private function getPageUrl(array $parts, array $parameters, $page)
+    {
 
         if (1. !== $page) {
             $parameters[$this->pageParameterName] = $page;
@@ -152,5 +173,38 @@ class CollectionNormalizer extends SerializerAwareNormalizer implements Normaliz
         }
 
         return $url;
+    }
+
+    /**
+     * Returns the content of the Hydra search property.
+     *
+     * @param ResourceInterface $resource
+     * @param array             $parts
+     * @param array             $filters
+     *
+     * @return array
+     */
+    private function getSearch(ResourceInterface $resource, array $parts, array $filters)
+    {
+        $variables = [];
+        $mapping = [];
+        foreach ($filters as $filter) {
+            foreach ($filter->getDescription($resource) as $variable => $data) {
+                $variables[] = $variable;
+                $mapping[] = [
+                    '@type' => 'IriTemplateMapping',
+                    'variable' => $variable,
+                    'property' => $data['property'],
+                    'required' => $data['required'],
+                ];
+            }
+        }
+
+        return [
+            '@type' => 'hydra:IriTemplate',
+            'hydra:template' => sprintf('%s{?%s}', $parts['path'], join(',', $variables)),
+            'hydra:variableRepresentation' => 'BasicRepresentation',
+            'hydra:mapping' => $mapping,
+        ];
     }
 }

--- a/features/collection.feature
+++ b/features/collection.feature
@@ -19,7 +19,38 @@ Feature: Collections support
       "hydra:itemsPerPage": 3,
       "hydra:firstPage": "/dummies",
       "hydra:lastPage": "/dummies",
-      "hydra:member": []
+      "hydra:member": [],
+      "hydra:search": {
+              "@type": "hydra:IriTemplate",
+              "hydra:template": "/dummies{?id,name,relatedDummy,relatedDummies}",
+              "hydra:variableRepresentation": "BasicRepresentation",
+              "hydra:mapping": [
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "id",
+                      "property": "id",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "name",
+                      "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummy",
+                      "property": "relatedDummy",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummies",
+                      "property": "relatedDummies",
+                      "required": false
+                  }
+              ]
+          }
     }
     """
 
@@ -68,7 +99,38 @@ Feature: Collections support
           "relatedDummy": null,
           "relatedDummies": []
         }
-      ]
+      ],
+      "hydra:search": {
+              "@type": "hydra:IriTemplate",
+              "hydra:template": "/dummies{?id,name,relatedDummy,relatedDummies}",
+              "hydra:variableRepresentation": "BasicRepresentation",
+              "hydra:mapping": [
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "id",
+                      "property": "id",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "name",
+                      "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummy",
+                      "property": "relatedDummy",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummies",
+                      "property": "relatedDummies",
+                      "required": false
+                  }
+              ]
+          }
     }
     """
 
@@ -117,7 +179,38 @@ Feature: Collections support
           "relatedDummy": null,
           "relatedDummies": []
         }
-      ]
+      ],
+      "hydra:search": {
+              "@type": "hydra:IriTemplate",
+              "hydra:template": "/dummies{?id,name,relatedDummy,relatedDummies}",
+              "hydra:variableRepresentation": "BasicRepresentation",
+              "hydra:mapping": [
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "id",
+                      "property": "id",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "name",
+                      "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummy",
+                      "property": "relatedDummy",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummies",
+                      "property": "relatedDummies",
+                      "required": false
+                  }
+              ]
+          }
     }
     """
 
@@ -165,7 +258,38 @@ Feature: Collections support
             "relatedDummy": null,
             "relatedDummies": []
           }
-      ]
+      ],
+      "hydra:search": {
+              "@type": "hydra:IriTemplate",
+              "hydra:template": "/dummies{?id,name,relatedDummy,relatedDummies}",
+              "hydra:variableRepresentation": "BasicRepresentation",
+              "hydra:mapping": [
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "id",
+                      "property": "id",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "name",
+                      "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummy",
+                      "property": "relatedDummy",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummies",
+                      "property": "relatedDummies",
+                      "required": false
+                  }
+              ]
+          }
     }
     """
 
@@ -301,7 +425,38 @@ Feature: Collections support
             
           ]
         }
-      ]
+      ],
+      "hydra:search": {
+              "@type": "hydra:IriTemplate",
+              "hydra:template": "/dummies{?id,name,relatedDummy,relatedDummies}",
+              "hydra:variableRepresentation": "BasicRepresentation",
+              "hydra:mapping": [
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "id",
+                      "property": "id",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "name",
+                      "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummy",
+                      "property": "relatedDummy",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummies",
+                      "property": "relatedDummies",
+                      "required": false
+                  }
+              ]
+          }
     }
     """
 
@@ -330,7 +485,38 @@ Feature: Collections support
             "relatedDummy": null,
             "relatedDummies": []
           }
-      ]
+      ],
+      "hydra:search": {
+              "@type": "hydra:IriTemplate",
+              "hydra:template": "/dummies{?id,name,relatedDummy,relatedDummies}",
+              "hydra:variableRepresentation": "BasicRepresentation",
+              "hydra:mapping": [
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "id",
+                      "property": "id",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "name",
+                      "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummy",
+                      "property": "relatedDummy",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummies",
+                      "property": "relatedDummies",
+                      "required": false
+                  }
+              ]
+          }
     }
     """
 
@@ -359,7 +545,38 @@ Feature: Collections support
             "relatedDummy": null,
             "relatedDummies": []
           }
-      ]
+      ],
+      "hydra:search": {
+              "@type": "hydra:IriTemplate",
+              "hydra:template": "/dummies{?id,name,relatedDummy,relatedDummies}",
+              "hydra:variableRepresentation": "BasicRepresentation",
+              "hydra:mapping": [
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "id",
+                      "property": "id",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "name",
+                      "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummy",
+                      "property": "relatedDummy",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummies",
+                      "property": "relatedDummies",
+                      "required": false
+                  }
+              ]
+          }
     }
     """
 
@@ -389,6 +606,37 @@ Feature: Collections support
             "relatedDummy": null,
             "relatedDummies": []
           }
-      ]
+      ],
+      "hydra:search": {
+              "@type": "hydra:IriTemplate",
+              "hydra:template": "/dummies{?id,name,relatedDummy,relatedDummies}",
+              "hydra:variableRepresentation": "BasicRepresentation",
+              "hydra:mapping": [
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "id",
+                      "property": "id",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "name",
+                      "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummy",
+                      "property": "relatedDummy",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummies",
+                      "property": "relatedDummies",
+                      "required": false
+                  }
+              ]
+          }
     }
     """

--- a/features/crud.feature
+++ b/features/crud.feature
@@ -73,7 +73,38 @@ Feature: Create-Retrieve-Update-Delete
           "relatedDummy": null,
           "relatedDummies": []
         }
-      ]
+      ],
+      "hydra:search": {
+              "@type": "hydra:IriTemplate",
+              "hydra:template": "/dummies{?id,name,relatedDummy,relatedDummies}",
+              "hydra:variableRepresentation": "BasicRepresentation",
+              "hydra:mapping": [
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "id",
+                      "property": "id",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "name",
+                      "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummy",
+                      "property": "relatedDummy",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummies",
+                      "property": "relatedDummies",
+                      "required": false
+                  }
+              ]
+          }
     }
     """
 

--- a/features/relation.feature
+++ b/features/relation.feature
@@ -81,7 +81,38 @@ Feature: Relations support
             "/related_dummies/1"
           ]
         }
-      ]
+      ],
+      "hydra:search": {
+              "@type": "hydra:IriTemplate",
+              "hydra:template": "/dummies{?id,name,relatedDummy,relatedDummies}",
+              "hydra:variableRepresentation": "BasicRepresentation",
+              "hydra:mapping": [
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "id",
+                      "property": "id",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "name",
+                      "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummy",
+                      "property": "relatedDummy",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummies",
+                      "property": "relatedDummies",
+                      "required": false
+                  }
+              ]
+          }
     }
     """
 


### PR DESCRIPTION
This PR add support for the [hydra:search](http://www.hydra-cg.com/spec/latest/core/#hydra:search) property. It adds filters auto-documentation in the Hydra format to the bundle. It also add supports for RFC 6570 and [Hydra Templated Links](http://www.hydra-cg.com/spec/latest/core/#templated-links).