### PR TITLE
Normalize attributeName

### DIFF
--- a/JsonLd/Serializer/ItemNormalizer.php
+++ b/JsonLd/Serializer/ItemNormalizer.php
@@ -121,7 +121,12 @@ class ItemNormalizer extends AbstractNormalizer
             if ('id' === $attributeName || !$attributeMetadata->isReadable()) {
                 continue;
             }
+
             $attributeValue = $this->propertyAccessor->getValue($object, $attributeName);
+
+            if ($this->nameConverter) {
+                $attributeName = $this->nameConverter->normalize($attributeName);
+            }
 
             if (isset($attributeMetadata->getTypes()[0])) {
                 $type = $attributeMetadata->getTypes()[0];


### PR DESCRIPTION
The nameConverter was used in denormalisation but not in normalisation.
This PR call the nameConverter to normalise attributeName in the normalisation process.