### PR TITLE
Simplify injection of nameConverter

### DIFF
--- a/Resources/config/json_ld.xml
+++ b/Resources/config/json_ld.xml
@@ -25,6 +25,7 @@
             <argument type="service" id="api.mapping.class_metadata_factory" />
             <argument type="service" id="api.json_ld.context_builder" />
             <argument type="service" id="property_accessor" />
+            <argument type="service" id="api.name_converter" on-invalid="ignore" />
 
             <tag name="serializer.normalizer" />
         </service>

--- a/Resources/doc/serialization-groups-and-relations.md
+++ b/Resources/doc/serialization-groups-and-relations.md
@@ -150,5 +150,21 @@ the data provider and any changes in the embedded relation will be applied to th
 
 You can create as relation embedding levels as you want.
 
+### Name convertion
+
+The Serializer Component provides a handy way to translate or map PHP field names to serialized names. See the
+[Symfony documentation](http://symfony.com/doc/master/components/serializer.html#converting-property-names-when-serializing-and-deserializing)
+
+To use this feature, declare a new service with id `api.name_converter`. For example, you can convert `CamelCase` to 
+`snake_case` with the following configuration:
+
+```yaml
+services:
+    # ...
+
+    api.name_converter:
+        class: Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter
+```
+
 Previous chapter: [Filters](filters.md)<br>
 Next chapter: [Validation](validation.md)


### PR DESCRIPTION
Actualy, injecting a nameConverter is quite complicated.
- Redefining the service or creating a new one with a higher priority
```
<service id="my_custom.normalizer.item" class="Dunglas\ApiBundle\JsonLd\Serializer\ItemNormalizer" public="false">
            <argument type="service" id="api.resource_collection" />
            <argument type="service" id="api.iri_converter" />
            <argument type="service" id="api.mapping.class_metadata_factory" />
            <argument type="service" id="api.json_ld.context_builder" />
            <argument type="service" id="property_accessor" />
            <argument type="service" id="my_custom.nameConverter" />

            <tag name="serializer.normalizer" />
        </service>
```
Or creating a CompilerPass
```
public function process(ContainerBuilder $container)
    {
        if (!$container->hasDefinition('api.json_ld.normalizer.item')) {
            return;
        }
        if (!$container->hasDefinition('serialization.name_converter')) {
            return;
        }

        $definition = $container->findDefinition('api.json_ld.normalizer.item');
        if (6 == count($definition->getArguments())) {
            $definition->replaceArgument(5, new Reference('my_custom.nameConverter'));
        } else {
            $definition->addArgument(new Reference('my_custom.nameConverter'));
        }
    }
```

This PR just add an inexisting service in the definition `api.json_ld.normalizer.item`. The user is now able to define is own `api.name_converter` to properly inject his nameConverter. (see documentation)

This PR should fix #29