### PR TITLE
Date filter

### DIFF
--- a/Doctrine/Orm/DateFilter.php
+++ b/Doctrine/Orm/DateFilter.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the DunglasApiBundle package.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Dunglas\ApiBundle\Doctrine\Orm;
+
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ORM\QueryBuilder;
+use Dunglas\ApiBundle\Api\ResourceInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * {@inheritdoc}
+ *
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+class DateFilter extends AbstractFilter
+{
+    /**
+     * @var array List of properties by witch the collection can or cannot be ordered.
+     */
+    private $properties;
+
+    /**
+     * @var string Keyword used to retrieve the value.
+     */
+    private $dateParameter;
+
+    /**
+     * @param ManagerRegistry $managerRegistry
+     * @param array|null      $properties      List of property names on which the filter will be enabled.
+     */
+    public function __construct(ManagerRegistry $managerRegistry, array $properties = null)
+    {
+        $this->managerRegistry = $managerRegistry;
+        $this->properties      = $properties;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Order collection by properties. The order of the ordered properties is the same as the order specified in the
+     * query.
+     */
+    public function apply(ResourceInterface $resource, QueryBuilder $queryBuilder, Request $request)
+    {
+        $metadata = $this->getClassMetadata($resource);
+        $fieldNames = $metadata->getFieldNames();
+
+        foreach ($request->query->all() as $filter => $values) {
+            // Check if value is an array
+            if (!is_array($values)) {
+                continue;
+            }
+
+            // Check if property is enabled or if filter is not enabled on all properties
+            if (null !== $this->properties) {
+                if (false === in_array($filter, $this->properties)) {
+                    continue;   // Skip this property
+                }
+            }
+
+            // Check if the entity has the property
+            if (true === in_array($filter, $fieldNames)) {
+                foreach ($values as $period => $date) {
+                    $period = strtolower($period);
+                    $date   = new \DateTime($date);
+
+                    if ('before' === $period) {
+                        $parameter = sprintf('%s%s', $period, $filter);
+                        $queryBuilder
+                            ->andWhere(sprintf('o.%s <= :%s', $filter, $parameter))
+                            ->setParameter($parameter, $date)
+                        ;
+                    }
+
+                    if ('after' === $period) {
+                        $parameter = sprintf('%s%s', $period, $filter);
+                        $queryBuilder
+                            ->andWhere(sprintf('o.%s >= :%s', $filter, $parameter))
+                            ->setParameter($parameter, $date)
+                        ;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription(ResourceInterface $resource)
+    {
+        $description = [];
+        $metadata = $this->getClassMetadata($resource);
+
+        foreach ($metadata->getFieldNames() as $fieldName) {
+            $found = in_array($fieldName, $this->properties);
+            //TODO: update description, how to handle the case of the period (`before` and `after`)?
+            if ($found || null === $this->properties) {
+                $description['string'] = [
+                    'property' => $fieldName,
+                    'type'     => 'string',
+                    'required' => false,
+                ];
+            }
+        }
+
+        return $description;
+    }
+}

--- a/Doctrine/Orm/OrderFilter.php
+++ b/Doctrine/Orm/OrderFilter.php
@@ -35,8 +35,8 @@ class OrderFilter extends AbstractFilter
 
     /**
      * @param ManagerRegistry $managerRegistry
-     * @param string          $orderParameter Keyword used to retrieve the value.
-     * @param array|null      $properties     List of property names on which the filter will be enabled/disabled.
+     * @param string          $orderParameter  Keyword used to retrieve the value.
+     * @param array|null      $properties      List of property names on which the filter will be enabled.
      */
     public function __construct(ManagerRegistry $managerRegistry, $orderParameter, array $properties = null)
     {
@@ -75,7 +75,7 @@ class OrderFilter extends AbstractFilter
             foreach ($values as $property => $order) {
                 $order = strtoupper($order);
 
-                // Check if property is enabled if filter is not enabled on all properties
+                // Check if property is enabled or if filter is not enabled on all properties
                 if (null !== $this->properties) {
                     if (false === in_array($property, $this->properties)) {
                         continue;   // Skip this property

--- a/Resources/config/doctrine_orm.xml
+++ b/Resources/config/doctrine_orm.xml
@@ -3,9 +3,6 @@
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-    <parameters>
-        <parameter key="api.doctrine.orm.order_filter.class">Dunglas\ApiBundle\Doctrine\Orm\OrderFilter</parameter>
-    </parameters>
 
     <services>
         <service id="api.doctrine.metadata_factory" class="Doctrine\Common\Persistence\Mapping\ClassMetadataFactory" public="false">
@@ -36,9 +33,13 @@
             <argument type="service" id="property_accessor" />
         </service>
 
-        <service id="api.doctrine.orm.order_filter" class="%api.doctrine.orm.order_filter.class%" public="false" abstract="true">
+        <service id="api.doctrine.orm.order_filter" class="Dunglas\ApiBundle\Doctrine\Orm\OrderFilter" public="false" abstract="true">
             <argument type="service" id="doctrine" />
             <argument>%api.collection.filter_name.order%</argument>
+        </service>
+
+        <service id="api.doctrine.orm.date_filter" class="Dunglas\ApiBundle\Doctrine\Orm\DateFilter" public="false" abstract="true">
+            <argument type="service" id="doctrine" />
         </service>
     </services>
 

--- a/Resources/doc/filters.md
+++ b/Resources/doc/filters.md
@@ -86,6 +86,39 @@ services:
         tags:      [ { name: "api.resource" } ]
 ```
 
+## Doctrine ORM date filter
+
+This filter allows you to filter a collection by dates periods.
+
+Syntax: `?property[<after|before>]=value`
+
+The period value (`after` or `before`) is case insensitive. The value can take any date format as long as it is understood by [`\DateTime()`](http://php.net/manual/fr/datetime.construct.php).
+
+To enable this filter on your ressource, just declare the following in your `app/config/services.yml`:
+
+```yaml
+# app/config/services.yml
+
+services:
+    # Enable date filter only for `dateProperty`
+    ressource.date_filter:
+        parent:    "api.doctrine.orm.date_filter"
+        arguments: [ ["dateProperty"] ]
+
+    # Enable date filter for all property
+    ressource.date_filter:
+        parent:    "api.doctrine.orm.date_filter"
+        arguments: [ ["dateProperty"] ]
+        
+    resource.offer:
+        parent:    "api.resource"
+        arguments: [ "AppBundle\Entity\Offer"] 
+        calls:
+            -      method:    "addFilter"
+                   arguments: [ "@resource.offer.date_filter" ]
+        tags:      [ { name: "api.resource" } ]
+```
+
 ## Doctrine ORM order filter
 
 This filter allows you to order a collection.

--- a/Tests/Behat/TestBundle/Entity/Dummy.php
+++ b/Tests/Behat/TestBundle/Entity/Dummy.php
@@ -115,4 +115,14 @@ class Dummy
     public function setFoo(array $foo = null)
     {
     }
+
+    public function setDummyDate(\DateTime $dummyDate)
+    {
+        $this->dummyDate = $dummyDate;
+    }
+
+    public function getDummyDate()
+    {
+        return $this->dummyDate;
+    }
 }

--- a/Tests/Doctrine/Orm/DateFilterTest.php
+++ b/Tests/Doctrine/Orm/DateFilterTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Dunglas\ApiBundle\Tests\Doctrine\Orm;
+
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Dunglas\ApiBundle\Doctrine\Orm\DateFilter;
+use Doctrine\ORM\EntityRepository;
+use Dunglas\ApiBundle\Api\Resource;
+use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class DateFilterTest.
+ *
+ * @@coversDefaultClass Dunglas\ApiBundle\Doctrine\Orm\DateFilter
+ *
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+class DateFilterTest extends KernelTestCase
+{
+    /**
+     * @var ManagerRegistry
+     */
+    private $managerRegistry;
+
+    /**
+     * @var EntityRepository
+     */
+    private $repository;
+
+    /**
+     * @var Resource
+     */
+    protected $resource;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        self::bootKernel();
+        $class                 = 'Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\Dummy';
+        $manager               = DoctrineTestHelper::createTestEntityManager();
+        $this->managerRegistry = self::$kernel->getContainer()->get('doctrine');
+        $this->repository      = $manager->getRepository($class);
+        $this->resource        = new Resource($class);
+    }
+
+    /**
+     * @covers ::apply
+     *
+     * @dataProvider filterProvider
+     */
+    public function testApply(array $filterParameters, array $query, $expected)
+    {
+        $request      = Request::create('/api/dummies', 'GET', $query);
+        $queryBuilder = $this->getQueryBuilder();
+        $filter       = new DateFilter(
+            $this->managerRegistry,
+            $filterParameters['properties']
+        );
+
+        $filter->apply($this->resource, $queryBuilder, $request);
+        $actual   = strtolower($queryBuilder->getQuery()->getDQL());
+        $expected = strtolower($expected);
+
+        $this->assertEquals(
+            $expected,
+            $actual,
+            sprintf('Expected `%s` for this `%s %s` request', $expected, 'GET', $request->getUri())
+        );
+    }
+
+    /**
+     * @return \Doctrine\ORM\QueryBuilder QueryBuilder for filters.
+     */
+    public function getQueryBuilder()
+    {
+        return $this->repository->createQueryBuilder('o');
+    }
+
+    /**
+     * Providers 3 parameters:
+     *  - filter parameters.
+     *  - properties to test. Keys are the property name. If the value is true, the filter should work on the property,
+     *    otherwise not.
+     *  - expected DQL query
+     *
+     * @return array
+     */
+    public function filterProvider()
+    {
+        return [
+            // Properties enabled with valid values
+            [
+                [
+                    'properties' => null,
+                ],
+                [
+                    'dummyDate' => [
+                        'after' => '2015-04-05'
+                    ]
+                ],
+                'SELECT o FROM Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\Dummy o where o.dummydate >= :afterdummydate'
+            ],
+            [
+                [
+                    'properties' => null,
+                ],
+                [
+                    'dummyDate' => [
+                        'after'  => '2015-04-05',
+                        'before' => '2015-04-05'
+                    ]
+                ],
+                'SELECT o FROM Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\Dummy o where o.dummydate >= :afterdummydate and o.dummydate <= :beforedummydate'
+            ],
+            [
+                [
+                    'properties' => ['unkown'],
+                ],
+                [
+                    'dummyDate' => [
+                        'after'  => '2015-04-05',
+                        'before' => '2015-04-05'
+                    ]
+                ],
+                'SELECT o FROM Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\Dummy o'
+            ]
+        ];
+    }
+}

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -70,6 +70,25 @@ class FeatureContext implements Context, SnippetAcceptingContext
     }
 
     /**
+     * @Given there is :nb dummy objects with dummyDate
+     */
+    public function thereIsDummyObjectsWithDummyDate($nb)
+    {
+        for ($i = 1; $i <= $nb; $i++) {
+            $date = new \DateTime(sprintf('2015-04-%d', $i), new \DateTimeZone('UTC'));
+
+            $dummy = new Dummy();
+            $dummy->setName('Dummy #'.$i);
+            $dummy->setAlias('Alias #'.($nb - $i));
+            $dummy->setDummyDate($date);
+
+            $this->manager->persist($dummy);
+        }
+
+        $this->manager->flush();
+    }
+
+    /**
      * @Given there is a RelationEmbedder object
      */
     public function thereIsARelationEmbedderObject()

--- a/features/collection-date-filter.feature
+++ b/features/collection-date-filter.feature
@@ -1,0 +1,437 @@
+Feature: Order filter on collections
+  In order to retrieve ordered large collections of resources
+  As a client software developer
+  I need to retrieve collections ordered properties
+
+  @createSchema
+  Scenario: Get collection filtered by date
+    Given there is "30" dummy objects with dummyDate
+    When I send a "GET" request to "/dummies?dummyDate[after]=2015-04-05"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/Dummy",
+      "@id": "/dummies?dummyDate[after]=2015-04-05",
+      "@type": "hydra:PagedCollection",
+      "hydra:nextPage": "/dummies?dummyDate%5Bafter%5D=2015-04-05&page=2",
+      "hydra:totalItems": 26,
+      "hydra:itemsPerPage": 3,
+      "hydra:firstPage": "/dummies?dummyDate%5Bafter%5D=2015-04-05",
+      "hydra:lastPage": "/dummies?dummyDate%5Bafter%5D=2015-04-05&page=9",
+      "hydra:member": [
+              {
+                  "@id": "/dummies/5",
+                  "@type": "Dummy",
+                  "name": "Dummy #5",
+                  "alias": "Alias #25",
+                  "dummyDate": "2015-04-05T00:00:00+00:00",
+                  "dummy": null,
+                  "relatedDummy": null,
+                  "relatedDummies": []
+              },
+              {
+                  "@id": "/dummies/6",
+                  "@type": "Dummy",
+                  "name": "Dummy #6",
+                  "alias": "Alias #24",
+                  "dummyDate": "2015-04-06T00:00:00+00:00",
+                  "dummy": null,
+                  "relatedDummy": null,
+                  "relatedDummies": []
+              },
+              {
+                  "@id": "/dummies/7",
+                  "@type": "Dummy",
+                  "name": "Dummy #7",
+                  "alias": "Alias #23",
+                  "dummyDate": "2015-04-07T00:00:00+00:00",
+                  "dummy": null,
+                  "relatedDummy": null,
+                  "relatedDummies": []
+              }
+          ],
+          "hydra:search": {
+              "@type": "hydra:IriTemplate",
+              "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name],string}",
+              "hydra:variableRepresentation": "BasicRepresentation",
+              "hydra:mapping": [
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "id",
+                      "property": "id",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "name",
+                      "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummy",
+                      "property": "relatedDummy",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummies",
+                      "property": "relatedDummies",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "order[id]",
+                      "property": "id",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "order[name]",
+                      "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "string",
+                      "property": "dummyDate",
+                      "required": false
+                  }
+              ]
+          }
+
+    }
+    """
+
+    When I send a "GET" request to "/dummies?dummyDate[before]=2015-04-05"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/Dummy",
+      "@id": "/dummies?dummyDate[before]=2015-04-05",
+      "@type": "hydra:PagedCollection",
+      "hydra:nextPage": "/dummies?dummyDate%5Bbefore%5D=2015-04-05&page=2",
+      "hydra:totalItems": 5,
+      "hydra:itemsPerPage": 3,
+      "hydra:firstPage": "/dummies?dummyDate%5Bbefore%5D=2015-04-05",
+      "hydra:lastPage": "/dummies?dummyDate%5Bbefore%5D=2015-04-05&page=2",
+      "hydra:member": [
+              {
+                  "@id": "/dummies/1",
+                  "@type": "Dummy",
+                  "name": "Dummy #1",
+                  "alias": "Alias #29",
+                  "dummyDate": "2015-04-01T00:00:00+00:00",
+                  "dummy": null,
+                  "relatedDummy": null,
+                  "relatedDummies": []
+              },
+              {
+                  "@id": "/dummies/2",
+                  "@type": "Dummy",
+                  "name": "Dummy #2",
+                  "alias": "Alias #28",
+                  "dummyDate": "2015-04-02T00:00:00+00:00",
+                  "dummy": null,
+                  "relatedDummy": null,
+                  "relatedDummies": []
+              },
+              {
+                  "@id": "/dummies/3",
+                  "@type": "Dummy",
+                  "name": "Dummy #3",
+                  "alias": "Alias #27",
+                  "dummyDate": "2015-04-03T00:00:00+00:00",
+                  "dummy": null,
+                  "relatedDummy": null,
+                  "relatedDummies": []
+              }
+          ],
+          "hydra:search": {
+              "@type": "hydra:IriTemplate",
+              "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name],string}",
+              "hydra:variableRepresentation": "BasicRepresentation",
+              "hydra:mapping": [
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "id",
+                      "property": "id",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "name",
+                      "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummy",
+                      "property": "relatedDummy",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummies",
+                      "property": "relatedDummies",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "order[id]",
+                      "property": "id",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "order[name]",
+                      "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "string",
+                      "property": "dummyDate",
+                      "required": false
+                  }
+              ]
+          }
+
+    }
+    """
+
+  Scenario: Search for entities within a range
+    # The order should not influence the search
+    When I send a "GET" request to "/dummies?dummyDate[before]=2015-04-05&dummyDate[after]=2015-04-05"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/Dummy",
+      "@id": "/dummies?dummyDate[before]=2015-04-05&dummyDate[after]=2015-04-05",
+      "@type": "hydra:PagedCollection",
+      "hydra:totalItems": 1,
+      "hydra:itemsPerPage": 3,
+      "hydra:firstPage": "/dummies?dummyDate%5Bbefore%5D=2015-04-05&dummyDate%5Bafter%5D=2015-04-05",
+      "hydra:lastPage": "/dummies?dummyDate%5Bbefore%5D=2015-04-05&dummyDate%5Bafter%5D=2015-04-05",
+      "hydra:member": [
+              {
+                  "@id": "/dummies/5",
+                  "@type": "Dummy",
+                  "name": "Dummy #5",
+                  "alias": "Alias #25",
+                  "dummyDate": "2015-04-05T00:00:00+00:00",
+                  "dummy": null,
+                  "relatedDummy": null,
+                  "relatedDummies": []
+              }
+          ],
+          "hydra:search": {
+              "@type": "hydra:IriTemplate",
+              "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name],string}",
+              "hydra:variableRepresentation": "BasicRepresentation",
+              "hydra:mapping": [
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "id",
+                      "property": "id",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "name",
+                      "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummy",
+                      "property": "relatedDummy",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummies",
+                      "property": "relatedDummies",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "order[id]",
+                      "property": "id",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "order[name]",
+                      "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "string",
+                      "property": "dummyDate",
+                      "required": false
+                  }
+              ]
+          }
+
+    }
+    """
+
+    When I send a "GET" request to "/dummies?dummyDate[after]=2015-04-05&dummyDate[before]=2015-04-05"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/Dummy",
+      "@id": "/dummies?dummyDate[after]=2015-04-05&dummyDate[before]=2015-04-05",
+      "@type": "hydra:PagedCollection",
+      "hydra:totalItems": 1,
+      "hydra:itemsPerPage": 3,
+      "hydra:firstPage": "/dummies?dummyDate%5Bafter%5D=2015-04-05&dummyDate%5Bbefore%5D=2015-04-05",
+      "hydra:lastPage": "/dummies?dummyDate%5Bafter%5D=2015-04-05&dummyDate%5Bbefore%5D=2015-04-05",
+      "hydra:member": [
+              {
+                  "@id": "/dummies/5",
+                  "@type": "Dummy",
+                  "name": "Dummy #5",
+                  "alias": "Alias #25",
+                  "dummyDate": "2015-04-05T00:00:00+00:00",
+                  "dummy": null,
+                  "relatedDummy": null,
+                  "relatedDummies": []
+              }
+          ],
+          "hydra:search": {
+              "@type": "hydra:IriTemplate",
+              "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name],string}",
+              "hydra:variableRepresentation": "BasicRepresentation",
+              "hydra:mapping": [
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "id",
+                      "property": "id",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "name",
+                      "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummy",
+                      "property": "relatedDummy",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummies",
+                      "property": "relatedDummies",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "order[id]",
+                      "property": "id",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "order[name]",
+                      "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "string",
+                      "property": "dummyDate",
+                      "required": false
+                  }
+              ]
+          }
+
+    }
+    """
+
+  @dropSchema
+  Scenario: Search for entities within an impossible range
+    When I send a "GET" request to "/dummies?dummyDate[after]=2015-04-06&dummyDate[before]=2015-04-04"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json"
+    And the JSON should be equal to:
+    """
+    {
+      "@context": "/contexts/Dummy",
+      "@id": "/dummies?dummyDate[after]=2015-04-06&dummyDate[before]=2015-04-04",
+      "@type": "hydra:PagedCollection",
+      "hydra:totalItems": 0,
+      "hydra:itemsPerPage": 3,
+      "hydra:firstPage": "/dummies?dummyDate%5Bafter%5D=2015-04-06&dummyDate%5Bbefore%5D=2015-04-04",
+      "hydra:lastPage": "/dummies?dummyDate%5Bafter%5D=2015-04-06&dummyDate%5Bbefore%5D=2015-04-04",
+      "hydra:member": [],
+          "hydra:search": {
+              "@type": "hydra:IriTemplate",
+              "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name],string}",
+              "hydra:variableRepresentation": "BasicRepresentation",
+              "hydra:mapping": [
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "id",
+                      "property": "id",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "name",
+                      "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummy",
+                      "property": "relatedDummy",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "relatedDummies",
+                      "property": "relatedDummies",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "order[id]",
+                      "property": "id",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "order[name]",
+                      "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "string",
+                      "property": "dummyDate",
+                      "required": false
+                  }
+              ]
+          }
+
+    }
+    """

--- a/features/collection-order-filter.feature
+++ b/features/collection-order-filter.feature
@@ -27,8 +27,8 @@ Feature: Order filter on collections
             "@type": "Dummy",
             "name": "Dummy #1",
             "alias": "Alias #29",
-            "dummy": null,
             "dummyDate": null,
+            "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
           },
@@ -37,8 +37,8 @@ Feature: Order filter on collections
             "@type": "Dummy",
             "name": "Dummy #2",
             "alias": "Alias #28",
-            "dummy": null,
             "dummyDate": null,
+            "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
           },
@@ -47,15 +47,15 @@ Feature: Order filter on collections
             "@type": "Dummy",
             "name": "Dummy #3",
             "alias": "Alias #27",
-            "dummy": null,
             "dummyDate": null,
+            "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
           }
       ],
       "hydra:search": {
         "@type": "hydra:IriTemplate",
-        "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name]}",
+        "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name],string}",
         "hydra:variableRepresentation": "BasicRepresentation",
         "hydra:mapping": [
             {
@@ -92,6 +92,12 @@ Feature: Order filter on collections
                 "@type": "IriTemplateMapping",
                 "variable": "order[name]",
                 "property": "name",
+                "required": false
+            },
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "string",
+                "property": "dummyDate",
                 "required": false
             }
         ]
@@ -121,8 +127,8 @@ Feature: Order filter on collections
             "@type": "Dummy",
             "name": "Dummy #30",
             "alias": "Alias #0",
-            "dummy": null,
             "dummyDate": null,
+            "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
           },
@@ -131,8 +137,8 @@ Feature: Order filter on collections
             "@type": "Dummy",
             "name": "Dummy #29",
             "alias": "Alias #1",
-            "dummy": null,
             "dummyDate": null,
+            "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
           },
@@ -141,15 +147,15 @@ Feature: Order filter on collections
             "@type": "Dummy",
             "name": "Dummy #28",
             "alias": "Alias #2",
-            "dummy": null,
             "dummyDate": null,
+            "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
           }
       ],
       "hydra:search": {
         "@type": "hydra:IriTemplate",
-        "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name]}",
+        "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name],string}",
         "hydra:variableRepresentation": "BasicRepresentation",
         "hydra:mapping": [
             {
@@ -186,6 +192,12 @@ Feature: Order filter on collections
                 "@type": "IriTemplateMapping",
                 "variable": "order[name]",
                 "property": "name",
+                "required": false
+            },
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "string",
+                "property": "dummyDate",
                 "required": false
             }
         ]
@@ -215,8 +227,8 @@ Feature: Order filter on collections
             "@type": "Dummy",
             "name": "Dummy #1",
             "alias": "Alias #29",
-            "dummy": null,
             "dummyDate": null,
+            "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
           },
@@ -225,8 +237,8 @@ Feature: Order filter on collections
             "@type": "Dummy",
             "name": "Dummy #10",
             "alias": "Alias #20",
-            "dummy": null,
             "dummyDate": null,
+            "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
           },
@@ -235,15 +247,15 @@ Feature: Order filter on collections
             "@type": "Dummy",
             "name": "Dummy #11",
             "alias": "Alias #19",
-            "dummy": null,
             "dummyDate": null,
+            "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
           }
       ],
       "hydra:search": {
         "@type": "hydra:IriTemplate",
-        "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name]}",
+        "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name],string}",
         "hydra:variableRepresentation": "BasicRepresentation",
         "hydra:mapping": [
             {
@@ -280,6 +292,12 @@ Feature: Order filter on collections
                 "@type": "IriTemplateMapping",
                 "variable": "order[name]",
                 "property": "name",
+                "required": false
+            },
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "string",
+                "property": "dummyDate",
                 "required": false
             }
         ]
@@ -309,8 +327,8 @@ Feature: Order filter on collections
             "@type": "Dummy",
             "name": "Dummy #9",
             "alias": "Alias #21",
-            "dummy": null,
             "dummyDate": null,
+            "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
           },
@@ -319,8 +337,8 @@ Feature: Order filter on collections
             "@type": "Dummy",
             "name": "Dummy #8",
             "alias": "Alias #22",
-            "dummy": null,
             "dummyDate": null,
+            "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
           },
@@ -329,15 +347,15 @@ Feature: Order filter on collections
             "@type": "Dummy",
             "name": "Dummy #7",
             "alias": "Alias #23",
-            "dummy": null,
             "dummyDate": null,
+            "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
           }
       ],
       "hydra:search": {
         "@type": "hydra:IriTemplate",
-        "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name]}",
+        "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name],string}",
         "hydra:variableRepresentation": "BasicRepresentation",
         "hydra:mapping": [
             {
@@ -374,6 +392,12 @@ Feature: Order filter on collections
                 "@type": "IriTemplateMapping",
                 "variable": "order[name]",
                 "property": "name",
+                "required": false
+            },
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "string",
+                "property": "dummyDate",
                 "required": false
             }
         ]
@@ -404,8 +428,8 @@ Feature: Order filter on collections
           "@type": "Dummy",
           "name": "Dummy #1",
           "alias": "Alias #29",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
         },
@@ -414,8 +438,8 @@ Feature: Order filter on collections
           "@type": "Dummy",
           "name": "Dummy #2",
           "alias": "Alias #28",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
         },
@@ -424,15 +448,15 @@ Feature: Order filter on collections
           "@type": "Dummy",
           "name": "Dummy #3",
           "alias": "Alias #27",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
         }
       ],
       "hydra:search": {
         "@type": "hydra:IriTemplate",
-        "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name]}",
+        "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name],string}",
         "hydra:variableRepresentation": "BasicRepresentation",
         "hydra:mapping": [
             {
@@ -469,6 +493,12 @@ Feature: Order filter on collections
                 "@type": "IriTemplateMapping",
                 "variable": "order[name]",
                 "property": "name",
+                "required": false
+            },
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "string",
+                "property": "dummyDate",
                 "required": false
             }
         ]
@@ -497,8 +527,8 @@ Feature: Order filter on collections
           "@type": "Dummy",
           "name": "Dummy #1",
           "alias": "Alias #29",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
         },
@@ -507,8 +537,8 @@ Feature: Order filter on collections
           "@type": "Dummy",
           "name": "Dummy #2",
           "alias": "Alias #28",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
         },
@@ -517,15 +547,15 @@ Feature: Order filter on collections
           "@type": "Dummy",
           "name": "Dummy #3",
           "alias": "Alias #27",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
         }
       ],
       "hydra:search": {
         "@type": "hydra:IriTemplate",
-        "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name]}",
+        "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name],string}",
         "hydra:variableRepresentation": "BasicRepresentation",
         "hydra:mapping": [
             {
@@ -562,6 +592,12 @@ Feature: Order filter on collections
                 "@type": "IriTemplateMapping",
                 "variable": "order[name]",
                 "property": "name",
+                "required": false
+            },
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "string",
+                "property": "dummyDate",
                 "required": false
             }
         ]
@@ -590,8 +626,8 @@ Feature: Order filter on collections
           "@type": "Dummy",
           "name": "Dummy #1",
           "alias": "Alias #29",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
         },
@@ -600,8 +636,8 @@ Feature: Order filter on collections
           "@type": "Dummy",
           "name": "Dummy #2",
           "alias": "Alias #28",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
         },
@@ -610,15 +646,15 @@ Feature: Order filter on collections
           "@type": "Dummy",
           "name": "Dummy #3",
           "alias": "Alias #27",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
         }
       ],
       "hydra:search": {
         "@type": "hydra:IriTemplate",
-        "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name]}",
+        "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name],string}",
         "hydra:variableRepresentation": "BasicRepresentation",
         "hydra:mapping": [
             {
@@ -655,6 +691,12 @@ Feature: Order filter on collections
                 "@type": "IriTemplateMapping",
                 "variable": "order[name]",
                 "property": "name",
+                "required": false
+            },
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "string",
+                "property": "dummyDate",
                 "required": false
             }
         ]
@@ -683,8 +725,8 @@ Feature: Order filter on collections
           "@type": "Dummy",
           "name": "Dummy #1",
           "alias": "Alias #29",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
         },
@@ -693,8 +735,8 @@ Feature: Order filter on collections
           "@type": "Dummy",
           "name": "Dummy #2",
           "alias": "Alias #28",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
         },
@@ -703,15 +745,15 @@ Feature: Order filter on collections
           "@type": "Dummy",
           "name": "Dummy #3",
           "alias": "Alias #27",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
         }
       ],
       "hydra:search": {
         "@type": "hydra:IriTemplate",
-        "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name]}",
+        "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name],string}",
         "hydra:variableRepresentation": "BasicRepresentation",
         "hydra:mapping": [
             {
@@ -748,6 +790,12 @@ Feature: Order filter on collections
                 "@type": "IriTemplateMapping",
                 "variable": "order[name]",
                 "property": "name",
+                "required": false
+            },
+            {
+                "@type": "IriTemplateMapping",
+                "variable": "string",
+                "property": "dummyDate",
                 "required": false
             }
         ]

--- a/features/collection.feature
+++ b/features/collection.feature
@@ -22,7 +22,7 @@ Feature: Collections support
       "hydra:member": [],
       "hydra:search": {
               "@type": "hydra:IriTemplate",
-              "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name]}",
+              "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name],string}",
               "hydra:variableRepresentation": "BasicRepresentation",
               "hydra:mapping": [
                   {
@@ -59,6 +59,12 @@ Feature: Collections support
                       "@type": "IriTemplateMapping",
                       "variable": "order[name]",
                       "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "string",
+                      "property": "dummyDate",
                       "required": false
                   }
               ]
@@ -89,8 +95,8 @@ Feature: Collections support
           "@type": "Dummy",
           "name": "Dummy #1",
           "alias": "Alias #29",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
         },
@@ -99,8 +105,8 @@ Feature: Collections support
           "@type": "Dummy",
           "name": "Dummy #2",
           "alias": "Alias #28",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
         },
@@ -109,15 +115,15 @@ Feature: Collections support
           "@type": "Dummy",
           "name": "Dummy #3",
           "alias": "Alias #27",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
         }
       ],
       "hydra:search": {
               "@type": "hydra:IriTemplate",
-              "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name]}",
+              "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name],string}",
               "hydra:variableRepresentation": "BasicRepresentation",
               "hydra:mapping": [
                   {
@@ -154,6 +160,12 @@ Feature: Collections support
                       "@type": "IriTemplateMapping",
                       "variable": "order[name]",
                       "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "string",
+                      "property": "dummyDate",
                       "required": false
                   }
               ]
@@ -184,8 +196,8 @@ Feature: Collections support
           "@type": "Dummy",
           "name": "Dummy #19",
           "alias": "Alias #11",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
         },
@@ -194,8 +206,8 @@ Feature: Collections support
           "@type": "Dummy",
           "name": "Dummy #20",
           "alias": "Alias #10",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
         },
@@ -204,15 +216,15 @@ Feature: Collections support
           "@type": "Dummy",
           "name": "Dummy #21",
           "alias": "Alias #9",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
         }
       ],
       "hydra:search": {
               "@type": "hydra:IriTemplate",
-              "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name]}",
+              "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name],string}",
               "hydra:variableRepresentation": "BasicRepresentation",
               "hydra:mapping": [
                   {
@@ -250,7 +262,14 @@ Feature: Collections support
                       "variable": "order[name]",
                       "property": "name",
                       "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "string",
+                      "property": "dummyDate",
+                      "required": false
                   }
+
               ]
       }
     }
@@ -278,8 +297,8 @@ Feature: Collections support
             "@type": "Dummy",
             "name": "Dummy #28",
             "alias": "Alias #2",
-            "dummy": null,
             "dummyDate": null,
+            "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
           },
@@ -288,8 +307,8 @@ Feature: Collections support
             "@type": "Dummy",
             "name": "Dummy #29",
             "alias": "Alias #1",
-            "dummy": null,
             "dummyDate": null,
+            "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
           },
@@ -298,15 +317,15 @@ Feature: Collections support
             "@type": "Dummy",
             "name": "Dummy #30",
             "alias": "Alias #0",
-            "dummy": null,
             "dummyDate": null,
+            "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
           }
       ],
       "hydra:search": {
               "@type": "hydra:IriTemplate",
-              "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name]}",
+              "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name],string}",
               "hydra:variableRepresentation": "BasicRepresentation",
               "hydra:mapping": [
                   {
@@ -343,6 +362,12 @@ Feature: Collections support
                       "@type": "IriTemplateMapping",
                       "variable": "order[name]",
                       "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "string",
+                      "property": "dummyDate",
                       "required": false
                   }
               ]
@@ -377,8 +402,8 @@ Feature: Collections support
           "@type": "Dummy",
           "name": "Dummy #11",
           "alias": "Alias #19",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": [
             
@@ -389,8 +414,8 @@ Feature: Collections support
           "@type": "Dummy",
           "name": "Dummy #12",
           "alias": "Alias #18",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": [
             
@@ -401,8 +426,8 @@ Feature: Collections support
           "@type": "Dummy",
           "name": "Dummy #13",
           "alias": "Alias #17",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": [
             
@@ -413,8 +438,8 @@ Feature: Collections support
           "@type": "Dummy",
           "name": "Dummy #14",
           "alias": "Alias #16",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": [
             
@@ -425,8 +450,8 @@ Feature: Collections support
           "@type": "Dummy",
           "name": "Dummy #15",
           "alias": "Alias #15",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": [
             
@@ -437,8 +462,8 @@ Feature: Collections support
           "@type": "Dummy",
           "name": "Dummy #16",
           "alias": "Alias #14",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": [
             
@@ -449,8 +474,8 @@ Feature: Collections support
           "@type": "Dummy",
           "name": "Dummy #17",
           "alias": "Alias #13",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": [
             
@@ -461,8 +486,8 @@ Feature: Collections support
           "@type": "Dummy",
           "name": "Dummy #18",
           "alias": "Alias #12",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": [
             
@@ -473,8 +498,8 @@ Feature: Collections support
           "@type": "Dummy",
           "name": "Dummy #19",
           "alias": "Alias #11",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": [
             
@@ -485,8 +510,8 @@ Feature: Collections support
           "@type": "Dummy",
           "name": "Dummy #20",
           "alias": "Alias #10",
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": [
             
@@ -495,7 +520,7 @@ Feature: Collections support
       ],
       "hydra:search": {
               "@type": "hydra:IriTemplate",
-              "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name]}",
+              "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name],string}",
               "hydra:variableRepresentation": "BasicRepresentation",
               "hydra:mapping": [
                   {
@@ -532,6 +557,12 @@ Feature: Collections support
                       "@type": "IriTemplateMapping",
                       "variable": "order[name]",
                       "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "string",
+                      "property": "dummyDate",
                       "required": false
                   }
               ]
@@ -560,15 +591,15 @@ Feature: Collections support
             "@type": "Dummy",
             "name": "Dummy #8",
             "alias": "Alias #22",
-            "dummy": null,
             "dummyDate": null,
+            "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
           }
       ],
       "hydra:search": {
               "@type": "hydra:IriTemplate",
-              "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name]}",
+              "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name],string}",
               "hydra:variableRepresentation": "BasicRepresentation",
               "hydra:mapping": [
                   {
@@ -606,7 +637,14 @@ Feature: Collections support
                       "variable": "order[name]",
                       "property": "name",
                       "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "string",
+                      "property": "dummyDate",
+                      "required": false
                   }
+
               ]
       }
     }
@@ -633,15 +671,15 @@ Feature: Collections support
             "@type": "Dummy",
             "name": "Dummy #8",
             "alias": "Alias #22",
-            "dummy": null,
             "dummyDate": null,
+            "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
           }
       ],
       "hydra:search": {
               "@type": "hydra:IriTemplate",
-              "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name]}",
+              "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name],string}",
               "hydra:variableRepresentation": "BasicRepresentation",
               "hydra:mapping": [
                   {
@@ -678,6 +716,12 @@ Feature: Collections support
                       "@type": "IriTemplateMapping",
                       "variable": "order[name]",
                       "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "string",
+                      "property": "dummyDate",
                       "required": false
                   }
               ]
@@ -707,15 +751,15 @@ Feature: Collections support
             "@type": "Dummy",
             "name": "Dummy #8",
             "alias": "Alias #22",
-            "dummy": null,
             "dummyDate": null,
+            "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
           }
       ],
       "hydra:search": {
               "@type": "hydra:IriTemplate",
-              "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name]}",
+              "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name],string}",
               "hydra:variableRepresentation": "BasicRepresentation",
               "hydra:mapping": [
                   {
@@ -752,6 +796,12 @@ Feature: Collections support
                       "@type": "IriTemplateMapping",
                       "variable": "order[name]",
                       "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "string",
+                      "property": "dummyDate",
                       "required": false
                   }
               ]

--- a/features/context.feature
+++ b/features/context.feature
@@ -17,8 +17,8 @@ Feature: JSON-LD contexts generation
             "name": "http://schema.org/name",
             "alias": "https://schema.org/alternateName",
             "foo": "#Dummy/foo",
-            "dummy": "#Dummy/dummy",
             "dummyDate": "#Dummy/dummyDate",
+            "dummy": "#Dummy/dummy",
             "relatedDummy": {
                 "@id": "#Dummy/relatedDummy",
                 "@type": "@id"
@@ -45,8 +45,8 @@ Feature: JSON-LD contexts generation
             "name": "http://schema.org/name",
             "alias": "https://schema.org/alternateName",
             "foo": "#Dummy/foo",
-            "dummy": "#Dummy/dummy",
             "dummyDate": "#Dummy/dummyDate",
+            "dummy": "#Dummy/dummy",
             "relatedDummy": {
                 "@id": "#Dummy/relatedDummy",
                 "@type": "@id"

--- a/features/crud.feature
+++ b/features/crud.feature
@@ -23,8 +23,8 @@ Feature: Create-Retrieve-Update-Delete
       "@type": "Dummy",
       "name": "My Dummy",
       "alias": null,
-      "dummy": null,
       "dummyDate": "2015-03-01T10:00:00+00:00",
+      "dummy": null,
       "relatedDummy": null,
       "relatedDummies": []
     }
@@ -43,8 +43,8 @@ Feature: Create-Retrieve-Update-Delete
       "@type": "Dummy",
       "name": "My Dummy",
       "alias": null,
-      "dummy": null,
       "dummyDate": "2015-03-01T10:00:00+00:00",
+      "dummy": null,
       "relatedDummy": null,
       "relatedDummies": []
     }
@@ -71,15 +71,15 @@ Feature: Create-Retrieve-Update-Delete
           "@type":"Dummy",
           "name":"My Dummy",
           "alias": null,
-          "dummy": null,
           "dummyDate": "2015-03-01T10:00:00+00:00",
+          "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
         }
       ],
       "hydra:search": {
               "@type": "hydra:IriTemplate",
-              "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name]}",
+              "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name],string}",
               "hydra:variableRepresentation": "BasicRepresentation",
               "hydra:mapping": [
                   {
@@ -117,6 +117,12 @@ Feature: Create-Retrieve-Update-Delete
                       "variable": "order[name]",
                       "property": "name",
                       "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "string",
+                      "property": "dummyDate",
+                      "required": false
                   }
               ]
       }
@@ -142,8 +148,8 @@ Feature: Create-Retrieve-Update-Delete
         "@type": "Dummy",
         "name": "A nice dummy",
         "alias": null,
-        "dummy": null,
         "dummyDate": "2015-03-01T10:00:00+00:00",
+        "dummy": null,
         "relatedDummy": null,
         "relatedDummies": []
       }

--- a/features/fixtures/TestApp/config/config.yml
+++ b/features/fixtures/TestApp/config/config.yml
@@ -35,6 +35,11 @@ dunglas_api:
                 enable_client_request: true
 
 services:
+    ressource.date_filter:
+        parent:    "api.doctrine.orm.date_filter"
+        arguments: [ ["dummyDate"] ]
+
+
     my_dummy_resource.search_filter:
         parent:                     "api.doctrine.orm.search_filter"
         arguments:                  [ { "id": "exact", "name": "partial" } ]
@@ -42,6 +47,10 @@ services:
     my_dummy_resource.order_filter:
         parent:                     "api.doctrine.orm.order_filter"
         arguments:                  [ ["id", "name"] ]
+
+    my_dummy_resource.date_filter:
+            parent:                 "api.doctrine.orm.date_filter"
+            arguments:              [ ["dummyDate"] ]
 
     my_dummy_resource:
         parent:                      "api.resource"
@@ -51,6 +60,8 @@ services:
                                        arguments: [ "@my_dummy_resource.search_filter" ]
                                      - method:    "addFilter"
                                        arguments: [ "@my_dummy_resource.order_filter" ]
+                                     - method:    "addFilter"
+                                       arguments: [ "@my_dummy_resource.date_filter" ]
         tags:                        [ { name: "api.resource" } ]
 
     my_related_dummy_resource:

--- a/features/relation.feature
+++ b/features/relation.feature
@@ -46,8 +46,8 @@ Feature: Relations support
       "@type": "Dummy",
       "name": "Dummy with relations",
       "alias": null,
-      "dummy": null,
       "dummyDate": null,
+      "dummy": null,
       "relatedDummy": "/related_dummies/1",
       "relatedDummies": [
         "/related_dummies/1"
@@ -76,8 +76,8 @@ Feature: Relations support
           "@type": "Dummy",
           "name": "Dummy with relations",
           "alias": null,
-          "dummy": null,
           "dummyDate": null,
+          "dummy": null,
           "relatedDummy": "/related_dummies/1",
           "relatedDummies": [
             "/related_dummies/1"
@@ -86,7 +86,7 @@ Feature: Relations support
       ],
       "hydra:search": {
               "@type": "hydra:IriTemplate",
-              "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name]}",
+              "hydra:template": "\/dummies{?id,name,relatedDummy,relatedDummies,order[id],order[name],string}",
               "hydra:variableRepresentation": "BasicRepresentation",
               "hydra:mapping": [
                   {
@@ -123,6 +123,12 @@ Feature: Relations support
                       "@type": "IriTemplateMapping",
                       "variable": "order[name]",
                       "property": "name",
+                      "required": false
+                  },
+                  {
+                      "@type": "IriTemplateMapping",
+                      "variable": "string",
+                      "property": "dummyDate",
                       "required": false
                   }
               ]

--- a/features/vocab.feature
+++ b/features/vocab.feature
@@ -102,21 +102,6 @@ Feature: Documentation support
                     {
                         "@type": "hydra:SupportedProperty",
                         "hydra:property": {
-                            "@id": "#Dummy/dummy",
-                            "@type": "rdf:Property",
-                            "rdfs:label": "dummy",
-                            "domain": "#Dummy",
-                            "range": "xmls:string"
-                        },
-                        "hydra:title": "dummy",
-                        "hydra:required": false,
-                        "hydra:readable": true,
-                        "hydra:writable": true,
-                        "hydra:description": "A dummy."
-                    },
-                    {
-                        "@type": "hydra:SupportedProperty",
-                        "hydra:property": {
                             "@id": "#Dummy/dummyDate",
                             "@type": "rdf:Property",
                             "rdfs:label": "dummyDate",
@@ -128,6 +113,21 @@ Feature: Documentation support
                         "hydra:readable": true,
                         "hydra:writable": true,
                         "hydra:description": "A dummy date."
+                    },
+                    {
+                        "@type": "hydra:SupportedProperty",
+                        "hydra:property": {
+                            "@id": "#Dummy/dummy",
+                            "@type": "rdf:Property",
+                            "rdfs:label": "dummy",
+                            "domain": "#Dummy",
+                            "range": "xmls:string"
+                        },
+                        "hydra:title": "dummy",
+                        "hydra:required": false,
+                        "hydra:readable": true,
+                        "hydra:writable": true,
+                        "hydra:description": "A dummy."
                     },
                     {
                         "@type": "hydra:SupportedProperty",


### PR DESCRIPTION
Add date filter support as requested in #46.

### Syntax

`?property[<before|after>]=value`

Where the period `before` or `after` is case insensitive and `value` a valid string for instantiate a `\DateTime()`.

### Config

```yaml
services:
    # Enable date filter only for `dateProperty`
    ressource.date_filter:
        parent:    "api.doctrine.orm.date_filter"
        arguments: [ ["dateProperty"] ]

    # Enable date filter for all property
    ressource.date_filter:
        parent:    "api.doctrine.orm.date_filter"
        arguments: [ ["dateProperty"] ]
```

Even if both search filter and date filter are enabled on all properties there is no conflict possible.