### PR TITLE
Use object index in serialized data

### DIFF
--- a/Hydra/Serializer/CollectionNormalizer.php
+++ b/Hydra/Serializer/CollectionNormalizer.php
@@ -80,8 +80,8 @@ class CollectionNormalizer extends SerializerAwareNormalizer implements Normaliz
 
         if (isset($context['json_ld_sub_level'])) {
             $data = [];
-            foreach ($object as $obj) {
-                $data[] = $this->serializer->normalize($obj, $format, $context);
+            foreach ($object as $index => $obj) {
+                $data[$index] = $this->serializer->normalize($obj, $format, $context);
             }
         } else {
             $data['@id'] = $context['request_uri'];

--- a/Tests/Behat/TestBundle/Entity/Dummy.php
+++ b/Tests/Behat/TestBundle/Entity/Dummy.php
@@ -77,6 +77,12 @@ class Dummy
      * @ORM\ManyToMany(targetEntity="RelatedDummy")
      */
     public $relatedDummies;
+    /**
+     * @var Array serialize data.
+     *
+     * @ORM\Column(type="json_array", nullable=true)
+     */
+    public $jsonData;
 
     public function __construct()
     {
@@ -124,5 +130,15 @@ class Dummy
     public function getDummyDate()
     {
         return $this->dummyDate;
+    }
+
+    public function setJsonData($jsonData)
+    {
+        $this->jsonData = $jsonData;
+    }
+
+    public function getJsonData()
+    {
+        return $this->jsonData;
     }
 }

--- a/Tests/Behat/TestBundle/Entity/Dummy.php
+++ b/Tests/Behat/TestBundle/Entity/Dummy.php
@@ -87,6 +87,7 @@ class Dummy
     public function __construct()
     {
         $this->relatedDummies = new ArrayCollection();
+        $this->jsonData = array();
     }
 
     public function getId()

--- a/features/collection-date-filter.feature
+++ b/features/collection-date-filter.feature
@@ -28,6 +28,7 @@ Feature: Order filter on collections
                   "name": "Dummy #5",
                   "alias": "Alias #25",
                   "dummyDate": "2015-04-05T00:00:00+00:00",
+                  "jsonData": [],
                   "dummy": null,
                   "relatedDummy": null,
                   "relatedDummies": []
@@ -38,6 +39,7 @@ Feature: Order filter on collections
                   "name": "Dummy #6",
                   "alias": "Alias #24",
                   "dummyDate": "2015-04-06T00:00:00+00:00",
+                  "jsonData": [],
                   "dummy": null,
                   "relatedDummy": null,
                   "relatedDummies": []
@@ -48,6 +50,7 @@ Feature: Order filter on collections
                   "name": "Dummy #7",
                   "alias": "Alias #23",
                   "dummyDate": "2015-04-07T00:00:00+00:00",
+                  "jsonData": [],
                   "dummy": null,
                   "relatedDummy": null,
                   "relatedDummies": []
@@ -128,6 +131,7 @@ Feature: Order filter on collections
                   "name": "Dummy #1",
                   "alias": "Alias #29",
                   "dummyDate": "2015-04-01T00:00:00+00:00",
+                  "jsonData": [],
                   "dummy": null,
                   "relatedDummy": null,
                   "relatedDummies": []
@@ -138,6 +142,7 @@ Feature: Order filter on collections
                   "name": "Dummy #2",
                   "alias": "Alias #28",
                   "dummyDate": "2015-04-02T00:00:00+00:00",
+                  "jsonData": [],
                   "dummy": null,
                   "relatedDummy": null,
                   "relatedDummies": []
@@ -148,6 +153,7 @@ Feature: Order filter on collections
                   "name": "Dummy #3",
                   "alias": "Alias #27",
                   "dummyDate": "2015-04-03T00:00:00+00:00",
+                  "jsonData": [],
                   "dummy": null,
                   "relatedDummy": null,
                   "relatedDummies": []
@@ -229,6 +235,7 @@ Feature: Order filter on collections
                   "name": "Dummy #5",
                   "alias": "Alias #25",
                   "dummyDate": "2015-04-05T00:00:00+00:00",
+                  "jsonData": [],
                   "dummy": null,
                   "relatedDummy": null,
                   "relatedDummies": []
@@ -308,6 +315,7 @@ Feature: Order filter on collections
                   "name": "Dummy #5",
                   "alias": "Alias #25",
                   "dummyDate": "2015-04-05T00:00:00+00:00",
+                  "jsonData": [],
                   "dummy": null,
                   "relatedDummy": null,
                   "relatedDummies": []

--- a/features/collection-order-filter.feature
+++ b/features/collection-order-filter.feature
@@ -28,6 +28,7 @@ Feature: Order filter on collections
             "name": "Dummy #1",
             "alias": "Alias #29",
             "dummyDate": null,
+            "jsonData": [],
             "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
@@ -38,6 +39,7 @@ Feature: Order filter on collections
             "name": "Dummy #2",
             "alias": "Alias #28",
             "dummyDate": null,
+            "jsonData": [],
             "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
@@ -48,6 +50,7 @@ Feature: Order filter on collections
             "name": "Dummy #3",
             "alias": "Alias #27",
             "dummyDate": null,
+            "jsonData": [],
             "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
@@ -128,6 +131,7 @@ Feature: Order filter on collections
             "name": "Dummy #30",
             "alias": "Alias #0",
             "dummyDate": null,
+            "jsonData": [],
             "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
@@ -138,6 +142,7 @@ Feature: Order filter on collections
             "name": "Dummy #29",
             "alias": "Alias #1",
             "dummyDate": null,
+            "jsonData": [],
             "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
@@ -148,6 +153,7 @@ Feature: Order filter on collections
             "name": "Dummy #28",
             "alias": "Alias #2",
             "dummyDate": null,
+            "jsonData": [],
             "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
@@ -228,6 +234,7 @@ Feature: Order filter on collections
             "name": "Dummy #1",
             "alias": "Alias #29",
             "dummyDate": null,
+            "jsonData": [],
             "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
@@ -238,6 +245,7 @@ Feature: Order filter on collections
             "name": "Dummy #10",
             "alias": "Alias #20",
             "dummyDate": null,
+            "jsonData": [],
             "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
@@ -248,6 +256,7 @@ Feature: Order filter on collections
             "name": "Dummy #11",
             "alias": "Alias #19",
             "dummyDate": null,
+            "jsonData": [],
             "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
@@ -328,6 +337,7 @@ Feature: Order filter on collections
             "name": "Dummy #9",
             "alias": "Alias #21",
             "dummyDate": null,
+            "jsonData": [],
             "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
@@ -338,6 +348,7 @@ Feature: Order filter on collections
             "name": "Dummy #8",
             "alias": "Alias #22",
             "dummyDate": null,
+            "jsonData": [],
             "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
@@ -348,6 +359,7 @@ Feature: Order filter on collections
             "name": "Dummy #7",
             "alias": "Alias #23",
             "dummyDate": null,
+            "jsonData": [],
             "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
@@ -429,6 +441,7 @@ Feature: Order filter on collections
           "name": "Dummy #1",
           "alias": "Alias #29",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
@@ -439,6 +452,7 @@ Feature: Order filter on collections
           "name": "Dummy #2",
           "alias": "Alias #28",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
@@ -449,6 +463,7 @@ Feature: Order filter on collections
           "name": "Dummy #3",
           "alias": "Alias #27",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
@@ -528,6 +543,7 @@ Feature: Order filter on collections
           "name": "Dummy #1",
           "alias": "Alias #29",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
@@ -538,6 +554,7 @@ Feature: Order filter on collections
           "name": "Dummy #2",
           "alias": "Alias #28",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
@@ -548,6 +565,7 @@ Feature: Order filter on collections
           "name": "Dummy #3",
           "alias": "Alias #27",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
@@ -627,6 +645,7 @@ Feature: Order filter on collections
           "name": "Dummy #1",
           "alias": "Alias #29",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
@@ -637,6 +656,7 @@ Feature: Order filter on collections
           "name": "Dummy #2",
           "alias": "Alias #28",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
@@ -647,6 +667,7 @@ Feature: Order filter on collections
           "name": "Dummy #3",
           "alias": "Alias #27",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
@@ -726,6 +747,7 @@ Feature: Order filter on collections
           "name": "Dummy #1",
           "alias": "Alias #29",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
@@ -736,6 +758,7 @@ Feature: Order filter on collections
           "name": "Dummy #2",
           "alias": "Alias #28",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
@@ -746,6 +769,7 @@ Feature: Order filter on collections
           "name": "Dummy #3",
           "alias": "Alias #27",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []

--- a/features/collection.feature
+++ b/features/collection.feature
@@ -96,6 +96,7 @@ Feature: Collections support
           "name": "Dummy #1",
           "alias": "Alias #29",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
@@ -106,6 +107,7 @@ Feature: Collections support
           "name": "Dummy #2",
           "alias": "Alias #28",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
@@ -116,6 +118,7 @@ Feature: Collections support
           "name": "Dummy #3",
           "alias": "Alias #27",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
@@ -197,6 +200,7 @@ Feature: Collections support
           "name": "Dummy #19",
           "alias": "Alias #11",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
@@ -207,6 +211,7 @@ Feature: Collections support
           "name": "Dummy #20",
           "alias": "Alias #10",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
@@ -217,6 +222,7 @@ Feature: Collections support
           "name": "Dummy #21",
           "alias": "Alias #9",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
@@ -298,6 +304,7 @@ Feature: Collections support
             "name": "Dummy #28",
             "alias": "Alias #2",
             "dummyDate": null,
+            "jsonData": [],
             "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
@@ -308,6 +315,7 @@ Feature: Collections support
             "name": "Dummy #29",
             "alias": "Alias #1",
             "dummyDate": null,
+            "jsonData": [],
             "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
@@ -318,6 +326,7 @@ Feature: Collections support
             "name": "Dummy #30",
             "alias": "Alias #0",
             "dummyDate": null,
+            "jsonData": [],
             "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
@@ -403,10 +412,11 @@ Feature: Collections support
           "name": "Dummy #11",
           "alias": "Alias #19",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": [
-            
+
           ]
         },
         {
@@ -415,10 +425,11 @@ Feature: Collections support
           "name": "Dummy #12",
           "alias": "Alias #18",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": [
-            
+
           ]
         },
         {
@@ -427,10 +438,11 @@ Feature: Collections support
           "name": "Dummy #13",
           "alias": "Alias #17",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": [
-            
+
           ]
         },
         {
@@ -439,10 +451,11 @@ Feature: Collections support
           "name": "Dummy #14",
           "alias": "Alias #16",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": [
-            
+
           ]
         },
         {
@@ -451,10 +464,11 @@ Feature: Collections support
           "name": "Dummy #15",
           "alias": "Alias #15",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": [
-            
+
           ]
         },
         {
@@ -463,10 +477,11 @@ Feature: Collections support
           "name": "Dummy #16",
           "alias": "Alias #14",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": [
-            
+
           ]
         },
         {
@@ -475,10 +490,11 @@ Feature: Collections support
           "name": "Dummy #17",
           "alias": "Alias #13",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": [
-            
+
           ]
         },
         {
@@ -487,10 +503,11 @@ Feature: Collections support
           "name": "Dummy #18",
           "alias": "Alias #12",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": [
-            
+
           ]
         },
         {
@@ -499,10 +516,11 @@ Feature: Collections support
           "name": "Dummy #19",
           "alias": "Alias #11",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": [
-            
+
           ]
         },
         {
@@ -511,10 +529,11 @@ Feature: Collections support
           "name": "Dummy #20",
           "alias": "Alias #10",
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": [
-            
+
           ]
         }
       ],
@@ -592,6 +611,7 @@ Feature: Collections support
             "name": "Dummy #8",
             "alias": "Alias #22",
             "dummyDate": null,
+            "jsonData": [],
             "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
@@ -672,6 +692,7 @@ Feature: Collections support
             "name": "Dummy #8",
             "alias": "Alias #22",
             "dummyDate": null,
+            "jsonData": [],
             "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []
@@ -752,6 +773,7 @@ Feature: Collections support
             "name": "Dummy #8",
             "alias": "Alias #22",
             "dummyDate": null,
+            "jsonData": [],
             "dummy": null,
             "relatedDummy": null,
             "relatedDummies": []

--- a/features/context.feature
+++ b/features/context.feature
@@ -18,6 +18,7 @@ Feature: JSON-LD contexts generation
             "alias": "https://schema.org/alternateName",
             "foo": "#Dummy/foo",
             "dummyDate": "#Dummy/dummyDate",
+            "jsonData": "#Dummy\/jsonData",
             "dummy": "#Dummy/dummy",
             "relatedDummy": {
                 "@id": "#Dummy/relatedDummy",
@@ -46,6 +47,7 @@ Feature: JSON-LD contexts generation
             "alias": "https://schema.org/alternateName",
             "foo": "#Dummy/foo",
             "dummyDate": "#Dummy/dummyDate",
+            "jsonData": "#Dummy\/jsonData",
             "dummy": "#Dummy/dummy",
             "relatedDummy": {
                 "@id": "#Dummy/relatedDummy",

--- a/features/crud.feature
+++ b/features/crud.feature
@@ -9,7 +9,13 @@ Feature: Create-Retrieve-Update-Delete
     """
     {
       "name": "My Dummy",
-      "dummyDate": "2015-03-01T10:00:00+00:00"
+      "dummyDate": "2015-03-01T10:00:00+00:00",
+      "jsonData": {
+        "key": [
+          "value1",
+          "value2"
+        ]
+      }
     }
     """
     Then the response status code should be 201
@@ -24,6 +30,12 @@ Feature: Create-Retrieve-Update-Delete
       "name": "My Dummy",
       "alias": null,
       "dummyDate": "2015-03-01T10:00:00+00:00",
+      "jsonData": {
+        "key": [
+          "value1",
+          "value2"
+        ]
+      },
       "dummy": null,
       "relatedDummy": null,
       "relatedDummies": []
@@ -44,6 +56,12 @@ Feature: Create-Retrieve-Update-Delete
       "name": "My Dummy",
       "alias": null,
       "dummyDate": "2015-03-01T10:00:00+00:00",
+      "jsonData": {
+        "key": [
+          "value1",
+          "value2"
+        ]
+      },
       "dummy": null,
       "relatedDummy": null,
       "relatedDummies": []
@@ -72,6 +90,12 @@ Feature: Create-Retrieve-Update-Delete
           "name":"My Dummy",
           "alias": null,
           "dummyDate": "2015-03-01T10:00:00+00:00",
+          "jsonData": {
+            "key": [
+              "value1",
+              "value2"
+            ]
+          },
           "dummy": null,
           "relatedDummy": null,
           "relatedDummies": []
@@ -134,7 +158,14 @@ Feature: Create-Retrieve-Update-Delete
       """
       {
         "@id": "/dummies/1",
-        "name": "A nice dummy"
+        "name": "A nice dummy",
+        "jsonData": [{
+            "key": "value1"
+          },
+          {
+            "key": "value2"
+          }
+        ]
       }
       """
       Then the response status code should be 202
@@ -149,6 +180,13 @@ Feature: Create-Retrieve-Update-Delete
         "name": "A nice dummy",
         "alias": null,
         "dummyDate": "2015-03-01T10:00:00+00:00",
+        "jsonData": [{
+            "key": "value1"
+          },
+          {
+            "key": "value2"
+          }
+        ],
         "dummy": null,
         "relatedDummy": null,
         "relatedDummies": []

--- a/features/relation.feature
+++ b/features/relation.feature
@@ -47,6 +47,7 @@ Feature: Relations support
       "name": "Dummy with relations",
       "alias": null,
       "dummyDate": null,
+      "jsonData": [],
       "dummy": null,
       "relatedDummy": "/related_dummies/1",
       "relatedDummies": [
@@ -77,6 +78,7 @@ Feature: Relations support
           "name": "Dummy with relations",
           "alias": null,
           "dummyDate": null,
+          "jsonData": [],
           "dummy": null,
           "relatedDummy": "/related_dummies/1",
           "relatedDummies": [

--- a/features/vocab.feature
+++ b/features/vocab.feature
@@ -117,6 +117,20 @@ Feature: Documentation support
                     {
                         "@type": "hydra:SupportedProperty",
                         "hydra:property": {
+                            "@id": "#Dummy\/jsonData",
+                            "@type": "rdf:Property",
+                            "rdfs:label": "jsonData",
+                            "domain": "#Dummy"
+                        },
+                        "hydra:title": "jsonData",
+                        "hydra:required": false,
+                        "hydra:readable": true,
+                        "hydra:writable": true,
+                        "hydra:description": "serialize data."
+                    },
+                    {
+                        "@type": "hydra:SupportedProperty",
+                        "hydra:property": {
                             "@id": "#Dummy/dummy",
                             "@type": "rdf:Property",
                             "rdfs:label": "dummy",


### PR DESCRIPTION
I'm not sure, i'm using the right way to do that, but, here is my problem.
I store complexe data in a field typed `json_array`. This data could be string, array, or object (json object == array(key =>value). 

This PR juste reuse the array key in the normalized data.

Tel me if you see an other way to do that.