### PR TITLE
Fix Range constraint in getting-started.md example

### DIFF
--- a/Resources/doc/getting-started.md
+++ b/Resources/doc/getting-started.md
@@ -139,7 +139,7 @@ class Offer
     /**
      * @ORM\Column(type="float")
      * @Assert\NotBlank
-     * @Assert\Range(min=0, message="The price must be superior to 0.")
+     * @Assert\Range(min=0, minMessage="The price must be superior to 0.")
      * @Assert\Type(type="float")
      */
     public $price;


### PR DESCRIPTION
The [`Range`](http://symfony.com/doc/current/reference/constraints/Range.html) constraint only supports `minMessage` and `maxMessage` but no `message` option, so this sample was wrong.