### PR TITLE
Null date are now after any date.

### DIFF
--- a/Tests/Doctrine/Orm/DateFilterTest.php
+++ b/Tests/Doctrine/Orm/DateFilterTest.php
@@ -58,7 +58,8 @@ class DateFilterTest extends KernelTestCase
         $queryBuilder = $this->getQueryBuilder();
         $filter = new DateFilter(
             $this->managerRegistry,
-            $filterParameters['properties']
+            $filterParameters['properties'],
+            $filterParameters['nullOption']
         );
 
         $filter->apply($this->resource, $queryBuilder, $request);
@@ -93,36 +94,129 @@ class DateFilterTest extends KernelTestCase
     {
         return [
             // Properties enabled with valid values
+            // Test after
             [
                 [
                     'properties' => null,
+                    'nullOption' => DateFilter::NULL_EXCLUDED,
                 ],
                 [
                     'dummyDate' => [
                         'after' => '2015-04-05',
                     ],
                 ],
-                'SELECT o FROM Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\Dummy o where o.dummydate >= :afterdummydate',
+                'SELECT o FROM Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\Dummy o WHERE o.dummydate >= :date_after_dummydate',
             ],
             [
                 [
                     'properties' => null,
+                    'nullOption' => DateFilter::NULL_FIRST,
                 ],
                 [
                     'dummyDate' => [
                         'after' => '2015-04-05',
+                    ],
+                ],
+                'SELECT o FROM Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\Dummy o WHERE o.dummydate >= :date_after_dummydate',
+            ],
+            [
+                [
+                    'properties' => null,
+                    'nullOption' => DateFilter::NULL_LAST,
+                ],
+                [
+                    'dummyDate' => [
+                        'after' => '2015-04-05',
+                    ],
+                ],
+                'SELECT o FROM Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\Dummy o WHERE o.dummydate >= :date_after_dummydate OR o.dummydate IS NULL',
+            ],
+            // Test before
+            [
+                [
+                    'properties' => null,
+                    'nullOption' => DateFilter::NULL_EXCLUDED,
+                ],
+                [
+                    'dummyDate' => [
                         'before' => '2015-04-05',
                     ],
                 ],
-                'SELECT o FROM Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\Dummy o where o.dummydate >= :afterdummydate and o.dummydate <= :beforedummydate',
+                'SELECT o FROM Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\Dummy o WHERE o.dummydate <= :date_before_dummydate AND o.dummydate IS NOT NULL',
             ],
             [
                 [
-                    'properties' => ['unkown'],
+                    'properties' => null,
+                    'nullOption' => DateFilter::NULL_FIRST,
                 ],
                 [
                     'dummyDate' => [
-                        'after' => '2015-04-05',
+                        'before' => '2015-04-05',
+                    ],
+                ],
+                'SELECT o FROM Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\Dummy o WHERE o.dummydate <= :date_before_dummydate',
+            ],
+            [
+                [
+                    'properties' => null,
+                    'nullOption' => DateFilter::NULL_LAST,
+                ],
+                [
+                    'dummyDate' => [
+                        'before' => '2015-04-05',
+                    ],
+                ],
+                'SELECT o FROM Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\Dummy o WHERE o.dummydate <= :date_before_dummydate AND o.dummydate IS NOT NULL',
+            ],
+            // with both after and before
+            [
+                [
+                    'properties' => null,
+                    'nullOption' => DateFilter::NULL_EXCLUDED,
+                ],
+                [
+                    'dummyDate' => [
+                        'after'  => '2015-04-05',
+                        'before' => '2015-04-05',
+                    ],
+                ],
+                'SELECT o FROM Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\Dummy o WHERE o.dummydate >= :date_after_dummydate AND (o.dummydate <= :date_before_dummydate AND o.dummydate IS NOT NULL)',
+            ],
+            [
+                [
+                    'properties' => null,
+                    'nullOption' => DateFilter::NULL_FIRST,
+                ],
+                [
+                    'dummyDate' => [
+                        'after'  => '2015-04-05',
+                        'before' => '2015-04-05',
+                    ],
+                ],
+                'SELECT o FROM Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\Dummy o WHERE o.dummydate >= :date_after_dummydate AND o.dummydate <= :date_before_dummydate',
+            ],
+            [
+                [
+                    'properties' => null,
+                    'nullOption' => DateFilter::NULL_LAST,
+                ],
+                [
+                    'dummyDate' => [
+                        'after'  => '2015-04-05',
+                        'before' => '2015-04-05',
+                    ],
+                ],
+                'SELECT o FROM Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\Dummy o WHERE (o.dummydate >= :date_after_dummydate OR o.dummydate IS NULL) AND (o.dummydate <= :date_before_dummydate AND o.dummydate IS NOT NULL)',
+            ],
+            // with no property enabled
+            [
+                [
+                    'properties' => ['unkown'],
+                    'nullOption' => 'does not exists',
+                ],
+                [
+                    'dummyDate' => [
+                        'after'  => '2015-04-05',
                         'before' => '2015-04-05',
                     ],
                 ],

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -79,7 +79,10 @@ class FeatureContext implements Context, SnippetAcceptingContext
             $dummy = new Dummy();
             $dummy->setName('Dummy #'.$i);
             $dummy->setAlias('Alias #'.($nb - $i));
-            $dummy->setDummyDate($date);
+            // Last Dummy has a null date
+            if ($nb !== $i) {
+                $dummy->setDummyDate($date);
+            }
 
             $this->manager->persist($dummy);
         }

--- a/features/collection-date-filterr.feature
+++ b/features/collection-date-filterr.feature
@@ -1,3 +1,4 @@
+@dateFilter
 Feature: Order filter on collections
   In order to retrieve ordered large collections of resources
   As a client software developer
@@ -6,7 +7,7 @@ Feature: Order filter on collections
   @createSchema
   Scenario: Get collection filtered by date
     Given there is "30" dummy objects with dummyDate
-    When I send a "GET" request to "/dummies?dummyDate[after]=2015-04-05"
+    When I send a "GET" request to "/dummies?dummyDate[after]=2015-04-28"
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json"
@@ -14,42 +15,41 @@ Feature: Order filter on collections
     """
     {
       "@context": "/contexts/Dummy",
-      "@id": "/dummies?dummyDate[after]=2015-04-05",
+      "@id": "/dummies?dummyDate[after]=2015-04-28",
       "@type": "hydra:PagedCollection",
-      "hydra:nextPage": "/dummies?dummyDate%5Bafter%5D=2015-04-05&page=2",
-      "hydra:totalItems": 26,
+      "hydra:totalItems": 3,
       "hydra:itemsPerPage": 3,
-      "hydra:firstPage": "/dummies?dummyDate%5Bafter%5D=2015-04-05",
-      "hydra:lastPage": "/dummies?dummyDate%5Bafter%5D=2015-04-05&page=9",
+      "hydra:firstPage": "/dummies?dummyDate%5Bafter%5D=2015-04-28",
+      "hydra:lastPage": "/dummies?dummyDate%5Bafter%5D=2015-04-28",
       "hydra:member": [
               {
-                  "@id": "/dummies/5",
+                  "@id": "/dummies/28",
                   "@type": "Dummy",
-                  "name": "Dummy #5",
-                  "alias": "Alias #25",
-                  "dummyDate": "2015-04-05T00:00:00+00:00",
+                  "name": "Dummy #28",
+                  "alias": "Alias #2",
+                  "dummyDate": "2015-04-28T00:00:00+00:00",
                   "jsonData": [],
                   "dummy": null,
                   "relatedDummy": null,
                   "relatedDummies": []
               },
               {
-                  "@id": "/dummies/6",
+                  "@id": "/dummies/29",
                   "@type": "Dummy",
-                  "name": "Dummy #6",
-                  "alias": "Alias #24",
-                  "dummyDate": "2015-04-06T00:00:00+00:00",
+                  "name": "Dummy #29",
+                  "alias": "Alias #1",
+                  "dummyDate": "2015-04-29T00:00:00+00:00",
                   "jsonData": [],
                   "dummy": null,
                   "relatedDummy": null,
                   "relatedDummies": []
               },
               {
-                  "@id": "/dummies/7",
+                  "@id": "/dummies/30",
                   "@type": "Dummy",
-                  "name": "Dummy #7",
-                  "alias": "Alias #23",
-                  "dummyDate": "2015-04-07T00:00:00+00:00",
+                  "name": "Dummy #30",
+                  "alias": "Alias #0",
+                  "dummyDate": null,
                   "jsonData": [],
                   "dummy": null,
                   "relatedDummy": null,

--- a/features/fixtures/TestApp/config/config.yml
+++ b/features/fixtures/TestApp/config/config.yml
@@ -50,7 +50,7 @@ services:
 
     my_dummy_resource.date_filter:
             parent:                 "api.doctrine.orm.date_filter"
-            arguments:              [ ["dummyDate"] ]
+            arguments:              [ ["dummyDate"], 2 ]
 
     my_dummy_resource:
         parent:                      "api.resource"


### PR DESCRIPTION
If we do a DQL query like `dummy.dummyDate <= :dateValue`, if `dummyDate` is null it will match this criteria. However a date field at null is often used to define an undetermined future date, i.e. a NULL date is expected to be higher than any date.

However I'm still concerned that some may which to keep a null date value as the lower value possible for a date. @dunglas what do you think? Should we add another parameter to configure this?

Also removed some duplication in code.