### PR TITLE
Use baseUrl within Router decorator

### DIFF
--- a/Routing/Router.php
+++ b/Routing/Router.php
@@ -85,7 +85,7 @@ class Router implements RouterInterface
 
         try {
             $this->router->setContext(new RequestContext(
-                '',
+                $baseContext->getBaseUrl(),
                 'GET',
                 $baseContext->getHost(),
                 $baseContext->getScheme(),


### PR DESCRIPTION
Fix issues when using the `app_dev.php` front controller, or any other base url.

For instance, if my project is accessible from the `localhost://my-project/` (when I'm too lazy for a proper vhost),  route generation was wrong.
I get stuck a while trying to get working the HydraConsole with one project, whereas I didn't get any issue on another one previously.

I saw the [commit](https://github.com/dunglas/DunglasApiBundle/commit/6986a4bb27ce0dac3ff48287df785204c8144add) introducing this Router decorator, but actually, I don't understand why is the baseUrl set to an empty string (and what's the purpose of this decorator ?).

As a witness, as I don't know much about Json-ld and Hydra yet, I tried the [Hydra Demo App](https://github.com/lanthaler/sfHydraDemoApp), and the api entrypoint properly looks like:
```json
{
    "@context": "/hydra-demo-app/web/app_dev.php/contexts/EntryPoint.jsonld",
    "@id": "/hydra-demo-app/web/app_dev.php/",
    "@type": "EntryPoint",
    "issues": "/hydra-demo-app/web/app_dev.php/issues/",
    "register_user": "/hydra-demo-app/web/app_dev.php/users/",
    "users": "/hydra-demo-app/web/app_dev.php/users/"
}
```

whereas with the current version, the api entrypoint of the demo ApiPlatform, using the `http://localhost/DunglasApiPlatform` url, looks like:

```json
{
    "@context": "/contexts/Entrypoint",
    "@id": "/",
    "@type": "Entrypoint",
    "book": "/books",
    "person": "/people",
    "organization": "/organizations"
}
``` 

which results into the HydraConsole searching for the `http://localhost/contexts/Entrypoint` path instead of `http://localhost/DunglasApiPlatform/contexts/Entrypoint`

In case I'm totally wrong, maybe you could clarify that for me ? :)