### PR TITLE
DateFilter: Use strict comparison for `nullOption` initialization check

### DIFF
--- a/Doctrine/Orm/DateFilter.php
+++ b/Doctrine/Orm/DateFilter.php
@@ -49,7 +49,7 @@ class DateFilter extends AbstractFilter
     {
         $this->managerRegistry = $managerRegistry;
         $this->properties = $properties;
-        if (in_array($nullOption, [self::NULL_EXCLUDED, self::NULL_FIRST, self::NULL_LAST])) {
+        if (in_array($nullOption, [self::NULL_EXCLUDED, self::NULL_FIRST, self::NULL_LAST], true)) {
             $this->nullOption = $nullOption;
         }
     }


### PR DESCRIPTION
Otherwise default `DateFilter::nullOption` was set to `null` instead of `NULL_FIRST = 1`. (`0 == null` is `true`)