### PR TITLE
Simplify router decorator & use real router where not needed

### DIFF
--- a/Resources/config/hydra.xml
+++ b/Resources/config/hydra.xml
@@ -8,7 +8,7 @@
         <service id="api.hydra.documentation_builder" class="Dunglas\ApiBundle\Hydra\ApiDocumentationBuilder">
             <argument type="service" id="api.resource_collection" />
             <argument type="service" id="api.json_ld.context_builder" />
-            <argument type="service" id="api.router" />
+            <argument type="service" id="router" />
             <argument type="service" id="api.mapping.class_metadata_factory" />
             <argument>%api.title%</argument>
             <argument>%api.description%</argument>
@@ -39,13 +39,13 @@
         </service>
 
         <service id="api.hydra.normalizer.constraint_violation_list" class="Dunglas\ApiBundle\Hydra\Serializer\ConstraintViolationListNormalizer" public="false" lazy="true">
-            <argument type="service" id="api.router" />
+            <argument type="service" id="router" />
 
             <tag name="serializer.normalizer" />
         </service>
 
         <service id="api.hydra.normalizer.error" class="Dunglas\ApiBundle\Hydra\Serializer\ErrorNormalizer" public="false" lazy="true">
-            <argument type="service" id="api.router" />
+            <argument type="service" id="router" />
             <argument>%kernel.debug%</argument>
 
             <tag name="serializer.normalizer" />

--- a/Resources/config/json_ld.xml
+++ b/Resources/config/json_ld.xml
@@ -8,11 +8,11 @@
         <service id="api.json_ld.entrypoint_builder" class="Dunglas\ApiBundle\JsonLd\EntrypointBuilder" lazy="true">
             <argument type="service" id="api.resource_collection" />
             <argument type="service" id="api.iri_converter" />
-            <argument type="service" id="api.router" />
+            <argument type="service" id="router" />
         </service>
 
         <service id="api.json_ld.context_builder" class="Dunglas\ApiBundle\JsonLd\ContextBuilder">
-            <argument type="service" id="api.router" />
+            <argument type="service" id="router" />
             <argument type="service" id="api.mapping.class_metadata_factory" />
             <argument type="service" id="api.resource_collection" />
         </service>

--- a/Routing/Router.php
+++ b/Routing/Router.php
@@ -81,21 +81,6 @@ class Router implements RouterInterface
      */
     public function generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH)
     {
-        $baseContext = $this->router->getContext();
-
-        try {
-            $this->router->setContext(new RequestContext(
-                $baseContext->getBaseUrl(),
-                'GET',
-                $baseContext->getHost(),
-                $baseContext->getScheme(),
-                $baseContext->getHttpPort(),
-                $baseContext->getHttpsPort()
-            ));
-
-            return $this->router->generate($name, $parameters, $referenceType);
-        } finally {
-            $this->router->setContext($baseContext);
-        }
+        return $this->router->generate($name, $parameters, $referenceType);
     }
 }


### PR DESCRIPTION
I forgot about this https://github.com/dunglas/DunglasApiBundle/pull/90#issuecomment-108009124 until now, and I indeed tried to replace the decorator by the Symfony router. Tests failed, as predicted.

But, actually, it only fails when trying to match a route, not generating one. So we can rely on the Symfony router and eliminate some unnecessary code.
Also, `match` method is only used within the `IriConverter` service, so it is the only one where we need to inject the decorator for now.

IMO, the decorator name and service name should reflect the issue. But honestly, I was unable to fully understand what is wrong with the Symfony router `match` method in our case (Overriding the method to `GET` in the context isn't sufficient for instance).
Do you have any idea about that, and naming properly the decorator ?