### PR TITLE
Fix denormalize allowedAttributes

### DIFF
--- a/JsonLd/Serializer/ItemNormalizer.php
+++ b/JsonLd/Serializer/ItemNormalizer.php
@@ -195,7 +195,7 @@ class ItemNormalizer extends AbstractNormalizer
 
         $allowedAttributes = [];
         foreach ($attributesMetadata as $attributeName => $attributeMetadata) {
-            if ($attributeMetadata->isReadable()) {
+            if ($attributeMetadata->isWritable()) {
                 $allowedAttributes[] = $attributeName;
             }
         }


### PR DESCRIPTION
This PR fix the following bug:
It's impossible to denormalize attributes in groups which are not allowed in normalization..
