### PR TITLE
Fix entrypointBuild error when resource has no Get COllection operation

### DIFF
--- a/Api/IriConverter.php
+++ b/Api/IriConverter.php
@@ -104,6 +104,14 @@ class IriConverter implements IriConverterInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function hasIriFromResource(ResourceInterface $resource)
+    {
+        return null !== $this->getRouteName($resource, 'collection');
+    }
+
+    /**
      * Gets the route name related to a resource.
      *
      * @param ResourceInterface $resource
@@ -133,5 +141,10 @@ class IriConverter implements IriConverterInterface
                 return $data[$key];
             }
         }
+
+        $data = $this->routeCache[$resource];
+        $data[$key] = null;
+        $this->routeCache[$resource] = $data;
+        return null;
     }
 }

--- a/Api/IriConverterInterface.php
+++ b/Api/IriConverterInterface.php
@@ -49,4 +49,13 @@ interface IriConverterInterface
      * @return string
      */
     public function getIriFromResource(ResourceInterface $resource, $referenceType = RouterInterface::ABSOLUTE_PATH);
+
+    /**
+     * Returns if the given resource collection has an IRI associated.
+     *
+     * @param ResourceInterface $resource
+     *
+     * @return bool
+     */
+    public function hasIriFromResource(ResourceInterface $resource);
 }

--- a/JsonLd/EntrypointBuilder.php
+++ b/JsonLd/EntrypointBuilder.php
@@ -59,6 +59,10 @@ class EntrypointBuilder
         ];
 
         foreach ($this->resourceCollection as $resource) {
+            if (!$this->iriConverter->hasIriFromResource($resource)) {
+                continue;
+            }
+
             $entrypoint[lcfirst($resource->getShortName())] = $this->iriConverter->getIriFromResource($resource);
         }
 


### PR DESCRIPTION
Here is my issue: When an resource does not have a Get operation on the Collection (I allow only POST), the entrypointBuilder fail to generate the route.

This PR remove the routes from such resources.
I'm not sure if I'm using the right way to do it. Tell me if you have a better way.