### PR TITLE
Keep indexes when deserializing data

### DIFF
--- a/JsonLd/Serializer/ItemNormalizer.php
+++ b/JsonLd/Serializer/ItemNormalizer.php
@@ -244,8 +244,8 @@ class ItemNormalizer extends AbstractNormalizer
                     ($class = $collectionType->getClass())
                 ) {
                     $values = [];
-                    foreach ($attributeValue as $obj) {
-                        $values[] = $this->denormalizeRelation(
+                    foreach ($attributeValue as $index => $obj) {
+                        $values[$index] = $this->denormalizeRelation(
                             $resource,
                             $attributesMetadata[$attributeName],
                             $class,


### PR DESCRIPTION
The same as #118, but for denormalization
(sorry for the double PR)