### PR TITLE
Require Symfony Serializer 2.7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   ],
   "require": {
     "php": ">=5.5",
-    "symfony/serializer": "~2.7|~3.0",
+    "symfony/serializer": "^2.7.2|~3.0",
     "symfony/validator": "~2.5|~3.0",
     "symfony/framework-bundle": "~2.6|~3.0",
     "symfony/proxy-manager-bridge": "~2.3",


### PR DESCRIPTION
To avoid a blocking bug when using the cache (symfony/symfony#15176)