### PR TITLE
Rename /vocab to /apidoc

### DIFF
--- a/Controller/HydraController.php
+++ b/Controller/HydraController.php
@@ -26,7 +26,7 @@ class HydraController extends Controller
      *
      * @return Response
      */
-    public function vocabAction()
+    public function docAction()
     {
         return new Response($this->get('api.hydra.documentation_builder')->getApiDocumentation());
     }

--- a/Resources/config/routing/hydra.xml
+++ b/Resources/config/routing/hydra.xml
@@ -5,7 +5,7 @@
         xsi:schemaLocation="http://symfony.com/schema/routing
         http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="api_hydra_vocab" path="/vocab">
-        <default key="_controller">DunglasApiBundle:Hydra:vocab</default>
+    <route id="api_hydra_vocab" path="/apidoc">
+        <default key="_controller">DunglasApiBundle:Hydra:doc</default>
     </route>
 </routes>

--- a/features/bootstrap/HydraContext.php
+++ b/features/bootstrap/HydraContext.php
@@ -27,7 +27,7 @@ class HydraContext implements Context
     }
 
     /**
-     * @Then :nb operations are availables for hydra class ":class"
+     * @Then :nb operations are available for hydra class ":class"
      */
     public function assertNbOperationsExist($nb, $className)
     {
@@ -40,7 +40,7 @@ class HydraContext implements Context
     }
 
     /**
-     * @Then :nb properties are availables for hydra class ":class"
+     * @Then :nb properties are available for hydra class ":class"
      */
     public function assertNbPropertiesExist($nb, $className)
     {

--- a/features/custom_identifier.feature
+++ b/features/custom_identifier.feature
@@ -84,13 +84,13 @@ Feature: Using custom identifier on resource
       }
       """
 
-  Scenario: Vocab is correctly generated
-    When I send a "GET" request to "/vocab"
+  Scenario: API doc is correctly generated
+    When I send a "GET" request to "/apidoc"
     Then the response status code should be 200
     And the response should be in JSON
     And the hydra class "CustomIdentifierDummy" exist
-    And 3 operations are availables for hydra class "CustomIdentifierDummy"
-    And 1 properties are availables for hydra class "CustomIdentifierDummy"
+    And 3 operations are available for hydra class "CustomIdentifierDummy"
+    And 1 properties are available for hydra class "CustomIdentifierDummy"
     And "name" property is readable for hydra class "CustomIdentifierDummy"
     And "name" property is writable for hydra class "CustomIdentifierDummy"
 

--- a/features/custom_normalized.feature
+++ b/features/custom_normalized.feature
@@ -89,13 +89,13 @@ Feature: Using custom normalized entity
       }
       """
 
-  Scenario: Vocab is correctly generated
-    When I send a "GET" request to "/vocab"
+  Scenario: API doc is correctly generated
+    When I send a "GET" request to "/apidoc"
     Then the response status code should be 200
     And the response should be in JSON
     And the hydra class "CustomNormalizedDummy" exist
-    And 3 operations are availables for hydra class "CustomNormalizedDummy"
-    And 2 properties are availables for hydra class "CustomNormalizedDummy"
+    And 3 operations are available for hydra class "CustomNormalizedDummy"
+    And 2 properties are available for hydra class "CustomNormalizedDummy"
     And "name" property is readable for hydra class "CustomNormalizedDummy"
     And "name" property is writable for hydra class "CustomNormalizedDummy"
     And "alias" property is readable for hydra class "CustomNormalizedDummy"

--- a/features/custom_writable_identifier.feature
+++ b/features/custom_writable_identifier.feature
@@ -86,13 +86,13 @@ Feature: Using custom writable identifier on resource
       }
       """
 
-  Scenario: Vocab is correctly generated
-    When I send a "GET" request to "/vocab"
+  Scenario: API doc is correctly generated
+    When I send a "GET" request to "/apidoc"
     Then the response status code should be 200
     And the response should be in JSON
     And the hydra class "CustomWritableIdentifierDummy" exist
-    And 3 operations are availables for hydra class "CustomWritableIdentifierDummy"
-    And 2 properties are availables for hydra class "CustomWritableIdentifierDummy"
+    And 3 operations are available for hydra class "CustomWritableIdentifierDummy"
+    And 2 properties are available for hydra class "CustomWritableIdentifierDummy"
     And "name" property is readable for hydra class "CustomWritableIdentifierDummy"
     And "name" property is writable for hydra class "CustomWritableIdentifierDummy"
     And "slug" property is not readable for hydra class "CustomWritableIdentifierDummy"

--- a/features/hydra/doc.feature
+++ b/features/hydra/doc.feature
@@ -5,10 +5,10 @@ Feature: Documentation support
 
   Scenario: Checks that the Link pointing to the Hydra documentation is set
     Given I send a "GET" request to "/"
-    Then the header "Link" should be equal to '<http://example.com/vocab>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation"'
+    Then the header "Link" should be equal to '<http://example.com/apidoc>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation"'
 
   Scenario: Retrieve the API vocabulary
-    Given I send a "GET" request to "/vocab"
+    Given I send a "GET" request to "/apidoc"
     Then the response status code should be 200
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json"
@@ -16,7 +16,7 @@ Feature: Documentation support
     """
     {
       "@context": {
-          "@vocab": "http:\/\/example.com\/vocab#",
+          "@vocab": "http:\/\/example.com\/apidoc#",
           "hydra": "http:\/\/www.w3.org\/ns\/hydra\/core#",
           "rdf": "http:\/\/www.w3.org\/1999\/02\/22-rdf-syntax-ns#",
           "rdfs": "http:\/\/www.w3.org\/2000\/01\/rdf-schema#",
@@ -43,7 +43,7 @@ Feature: Documentation support
               "@type": "@id"
           }
       },
-      "@id": "\/vocab",
+      "@id": "\/apidoc",
       "hydra:title": "My Dummy API",
       "hydra:description": "This is a test API.",
       "hydra:entrypoint": "\/",

--- a/features/json-ld/context.feature
+++ b/features/json-ld/context.feature
@@ -12,7 +12,7 @@ Feature: JSON-LD contexts generation
     """
     {
         "@context": {
-            "@vocab": "http://example.com/vocab#",
+            "@vocab": "http://example.com/apidoc#",
             "hydra": "http://www.w3.org/ns/hydra/core#",
             "name": "http://schema.org/name",
             "alias": "https://schema.org/alternateName",
@@ -42,7 +42,7 @@ Feature: JSON-LD contexts generation
     """
     {
         "@context": {
-            "@vocab": "http://example.com/vocab#",
+            "@vocab": "http://example.com/apidoc#",
             "hydra": "http://www.w3.org/ns/hydra/core#",
             "name": "http://schema.org/name",
             "alias": "https://schema.org/alternateName",
@@ -72,7 +72,7 @@ Feature: JSON-LD contexts generation
       """
       {
         "@context": {
-          "@vocab": "http://example.com/vocab#",
+          "@vocab": "http://example.com/apidoc#",
           "hydra": "http://www.w3.org/ns/hydra/core#",
           "related": "#RelationEmbedder/related",
           "paris": "#RelationEmbedder/paris",


### PR DESCRIPTION
As advised by @lanthaler on the Hydra mailing list.
Also fix a typo.