### PR TITLE
allow operation definition in service declaration

### DIFF
--- a/Resources/doc/operations.md
+++ b/Resources/doc/operations.md
@@ -20,30 +20,9 @@ By default, the following operations are automatically enabled:
 
 ## Disabling operations
 
-If you want to disable some operations (e.g. the `DELETE` operation), you must register manually applicable operations using
-the operation factory class, `Dunglas\ApiBundle\Resource::addCollectionOperation()` and `Dunglas\ApiBundle\Resource::addCollectionOperation()`
-methods.
+You can specify the list of operation to enable by setting two properties `collectionOperations` and `itemOperations`.
 
-The following `Resource` definition exposes a `GET` operation for it's collection but not the `POST` one:
-
-```yaml
-services:
-    resource.product.collection_operation.get:
-        class:     "Dunglas\ApiBundle\Api\Operation\Operation"
-        public:    false
-        factory:   [ "@api.operation_factory", "createCollectionOperation" ]
-        arguments: [ "@resource.product", "GET" ]
-
-    resource.product:
-        parent:    "api.resource"
-        arguments: [ "AppBundle\Entity\Product" ]
-        calls:
-            -      [ "initCollectionOperations", [ [ "@resource.product.collection_operation.get" ] ] ]
-        tags:      [ { name: "api.resource" } ]
-```
-
-However, in the following example items operations will still be automatically registered. To disable them, call `initItemOperations`
-with an empty array as first parameter:
+The following example allow only GET on collections and GET / PUT on item calls.
 
 ```yaml
 # ...
@@ -51,9 +30,7 @@ with an empty array as first parameter:
     resource.product:
         parent:    "api.resource"
         arguments: [ "AppBundle\Entity\Product" ]
-        calls:
-            -      [ "initItemOperations", [ [ ] ] ]
-            -      [ "initCollectionOperations", [ [ "@resource.product.collection_operation.get" ] ] ]
+        properties: properties: { collectionOperations: ["GET"], itemOperations: ["GET", "PUT"] }
         tags:      [ { name: "api.resource" } ]
 ```
 

--- a/Tests/DependencyInjection/Compiler/ResourcePassTest.php
+++ b/Tests/DependencyInjection/Compiler/ResourcePassTest.php
@@ -31,12 +31,15 @@ class ResourcePassTest extends \PHPUnit_Framework_TestCase
 
         $customResourceDefinitionProphecy = $this->prophesize('Symfony\Component\DependencyInjection\Definition');
         $customResourceDefinitionProphecy->getClass()->willReturn('Foo\Bar')->shouldBeCalled();
+        $customResourceDefinitionProphecy->getProperties(Argument::any())->shouldBeCalled();
         $customResourceDefinitionProphecy->hasMethodCall(Argument::any())->shouldNotBeCalled();
         $customResourceDefinitionProphecy->addMethodCall(Argument::any())->shouldNotBeCalled();
         $customResourceDefinition = $customResourceDefinitionProphecy->reveal();
 
         $builtinResourceDefinitionProphecy = $this->prophesize('Symfony\Component\DependencyInjection\Definition');
         $builtinResourceDefinitionProphecy->getClass()->willReturn('Dunglas\ApiBundle\Api\Resource')->shouldBeCalled();
+        $builtinResourceDefinitionProphecy->getProperties(Argument::any())->shouldBeCalled();
+        $builtinResourceDefinitionProphecy->setProperties(Argument::any())->shouldBeCalled();
         $builtinResourceDefinitionProphecy->hasMethodCall('initItemOperations')->willReturn(true)->shouldBeCalled();
         $builtinResourceDefinitionProphecy->addMethodCall('initItemOperations')->shouldNotBeCalled();
         $builtinResourceDefinitionProphecy->hasMethodCall('initCollectionOperations', Argument::any())->willReturn(true)->shouldBeCalled();
@@ -49,6 +52,8 @@ class ResourcePassTest extends \PHPUnit_Framework_TestCase
 
         $decoratedResourceDefinitionProphecy = $this->prophesize('Symfony\Component\DependencyInjection\DefinitionDecorator');
         $decoratedResourceDefinitionProphecy->getClass()->willReturn(false)->shouldBeCalled();
+        $decoratedResourceDefinitionProphecy->getProperties(Argument::any())->shouldBeCalled();
+        $decoratedResourceDefinitionProphecy->setProperties(Argument::any())->shouldBeCalled();
         $decoratedResourceDefinitionProphecy->getParent()->willReturn('inner_resource')->shouldBeCalled();
         $decoratedResourceDefinitionProphecy->hasMethodCall('initItemOperations')->willReturn(false)->shouldBeCalled();
         $decoratedResourceDefinitionProphecy->addMethodCall('initItemOperations', Argument::type('array'))->shouldBeCalled();


### PR DESCRIPTION
Disabling an operation is quite a painful process: you have to redeclare every call, and then inject them via the `initItemOperations` or `inicCollectionOperations`.

I added a way to specify the methods you want in the collection or the item calls.

I added two keys in the `properties` service definition. It is kind of a dirty way, but the `tag` definition do not allow array declaration and I do not think there is another way to do that ? 

Moreover I did not understand the test class on the ResourcePass, if you can help me with that ?

Thank you