### PR TITLE
Introduced IriHelper service

### DIFF
--- a/Doctrine/Orm/Filter/SearchFilter.php
+++ b/Doctrine/Orm/Filter/SearchFilter.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\QueryBuilder;
 use Dunglas\ApiBundle\Api\IriConverterInterface;
 use Dunglas\ApiBundle\Api\ResourceInterface;
+use Dunglas\ApiBundle\Util\Orm\IdExtractorTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
@@ -25,6 +26,8 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
  */
 class SearchFilter extends AbstractFilter
 {
+    use IdExtractorTrait;
+
     /**
      * @var string Exact matching.
      */
@@ -78,7 +81,7 @@ class SearchFilter extends AbstractFilter
 
             if (isset($fieldNames[$property])) {
                 if ('id' === $property) {
-                    $value = $this->getFilterValueFromUrl($value);
+                    $value = $this->getIdValueFromUrl($value);
                 }
 
                 $queryBuilder
@@ -88,7 +91,7 @@ class SearchFilter extends AbstractFilter
             } elseif ($metadata->isSingleValuedAssociation($property)
                 || $metadata->isCollectionValuedAssociation($property)
             ) {
-                $value = $this->getFilterValueFromUrl($value);
+                $value = $this->getIdValueFromUrl($value);
 
                 $queryBuilder
                     ->join(sprintf('o.%s', $property), $property)
@@ -131,25 +134,5 @@ class SearchFilter extends AbstractFilter
         }
 
         return $description;
-    }
-
-    /**
-     * Gets the ID from an URI or a raw ID.
-     *
-     * @param string $value
-     *
-     * @return string
-     */
-    private function getFilterValueFromUrl($value)
-    {
-        try {
-            if ($item = $this->iriConverter->getItemFromIri($value)) {
-                return $this->propertyAccessor->getValue($item, 'id');
-            }
-        } catch (\InvalidArgumentException $e) {
-            // Do nothing, return the raw value
-        }
-
-        return $value;
     }
 }

--- a/Util/Doctrine/Orm/IdExtractorTrait.php
+++ b/Util/Doctrine/Orm/IdExtractorTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the DunglasApiBundle package.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Dunglas\ApiBundle\Util\Orm;
+
+/**
+ * Retrieves information about a class.
+ *
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+trait IdExtractorTrait
+{
+    /**
+     * Gets the ID from an URI or a raw ID.
+     *
+     * @param string $value
+     *
+     * @return string
+     */
+    protected function getIdValueFromUrl($value)
+    {
+        try {
+            if ($item = $this->iriConverter->getItemFromIri($value)) {
+                return $this->propertyAccessor->getValue($item, 'id');
+            }
+        } catch (\InvalidArgumentException $e) {
+            // Do nothing, return the raw value
+        }
+
+        return $value;
+    }
+}


### PR DESCRIPTION
Extracted the `getFilterValueFromUrl()` function into a dedicated service. For the bundle itself, this function is used only by the `SearchFilter`. However this allow to give access to this function which is often needed for custom search filters (which extend or not `SearchFilter`).

I'm not sure it's the good way to do it. making this function `protected` would not help if you're using a complete custom `SearchFilter` for which it wouldn't make sense to extend `SearchFilter`, like for instance [`LoopBackApiBundle\Filter\WhereFilter`](https://github.com/theofidry/LoopBackApiBundle/blob/master/Filter/WhereFilter.php), and using a trait would be here very much like being a plain ugly copy/paste.

* [ ] Add tests
* [ ] Mention in the doc