### PR TITLE
Allow listeners execution for subrequests

### DIFF
--- a/Doctrine/EventListener/ManagerViewListener.php
+++ b/Doctrine/EventListener/ManagerViewListener.php
@@ -43,10 +43,6 @@ class ManagerViewListener
      */
     public function onKernelView(GetResponseForControllerResultEvent $event)
     {
-        if (!$event->isMasterRequest()) {
-            return;
-        }
-
         $request = $event->getRequest();
         if (!in_array($request->getMethod(), [Request::METHOD_POST, Request::METHOD_PUT, Request::METHOD_DELETE])) {
             return;

--- a/EventListener/FormatRequestListener.php
+++ b/EventListener/FormatRequestListener.php
@@ -47,10 +47,6 @@ class FormatRequestListener
      */
     public function onKernelRequest(GetResponseEvent $event)
     {
-        if (!$event->isMasterRequest()) {
-            return;
-        }
-
         $request = $event->getRequest();
         if (!$request->attributes->get('_resource_type')) {
             return;

--- a/EventListener/ResourceTypeRequestListener.php
+++ b/EventListener/ResourceTypeRequestListener.php
@@ -39,10 +39,6 @@ class ResourceTypeRequestListener
      */
     public function onKernelRequest(GetResponseEvent $event)
     {
-        if (!$event->isMasterRequest()) {
-            return;
-        }
-
         $request = $event->getRequest();
         if (!$request->attributes->has('_resource')) {
             return;

--- a/EventListener/ValidationViewListener.php
+++ b/EventListener/ValidationViewListener.php
@@ -44,10 +44,6 @@ class ValidationViewListener
      */
     public function onKernelView(GetResponseForControllerResultEvent $event)
     {
-        if (!$event->isMasterRequest()) {
-            return;
-        }
-
         $resourceType = $event->getRequest()->attributes->get('_resource_type');
         if (!$resourceType || !in_array($event->getRequest()->getMethod(), [Request::METHOD_POST, Request::METHOD_PUT])) {
             return;

--- a/Hydra/EventListener/LinkHeaderResponseListener.php
+++ b/Hydra/EventListener/LinkHeaderResponseListener.php
@@ -40,10 +40,6 @@ class LinkHeaderResponseListener
      */
     public function onKernelResponse(FilterResponseEvent $event)
     {
-        if (!$event->isMasterRequest()) {
-            return;
-        }
-
         $event->getResponse()->headers->set('Link', sprintf(
             '<%s>; rel="%sapiDocumentation"',
             $this->router->generate('api_hydra_vocab', [], UrlGeneratorInterface::ABSOLUTE_URL), ContextBuilder::HYDRA_NS)

--- a/Hydra/EventListener/RequestExceptionListener.php
+++ b/Hydra/EventListener/RequestExceptionListener.php
@@ -44,10 +44,6 @@ class RequestExceptionListener
      */
     public function onKernelException(GetResponseForExceptionEvent $event)
     {
-        if (!$event->isMasterRequest()) {
-            return;
-        }
-
         $request = $event->getRequest();
         if (!$request->attributes->has('_resource_type') || self::FORMAT !== $request->attributes->get('_api_format')) {
             return;

--- a/JsonLd/EventListener/ResponderViewListener.php
+++ b/JsonLd/EventListener/ResponderViewListener.php
@@ -45,10 +45,6 @@ class ResponderViewListener
      */
     public function onKernelView(GetResponseForControllerResultEvent $event)
     {
-        if (!$event->isMasterRequest()) {
-            return;
-        }
-
         $controllerResult = $event->getControllerResult();
 
         if ($controllerResult instanceof Response) {

--- a/Tests/Behat/TestBundle/EventListener/XmlResponderViewListener.php
+++ b/Tests/Behat/TestBundle/EventListener/XmlResponderViewListener.php
@@ -44,10 +44,6 @@ class XmlResponderViewListener
      */
     public function onKernelView(GetResponseForControllerResultEvent $event)
     {
-        if (!$event->isMasterRequest()) {
-            return;
-        }
-
         $controllerResult = $event->getControllerResult();
 
         if ($controllerResult instanceof Response) {


### PR DESCRIPTION
Should we really limit those listeners to master requests ?

Here is my use case:
We have a BulkRequest system that allows to execute multiple requests at once, through a payload describing requests to execute.
This system directly use the `kernel` and sub requests to handle the described requests and gather their responses to be finally sent in a single one to the client.

This system won't work anymore with the latest version of the api bundle.