### PR TITLE
Remove useless arguments

### DIFF
--- a/FosUser/EventListener.php
+++ b/FosUser/EventListener.php
@@ -53,7 +53,7 @@ class EventListener
                 break;
 
             case Request::METHOD_DELETE:
-                $this->userManager->deleteUser($user, false);
+                $this->userManager->deleteUser($user);
                 $event->setControllerResult(null);
                 break;
         }


### PR DESCRIPTION
The `UserManager::deleteUser` does not take a second parameter and do the persist + flush right away so it would not make much sense to no do the flush with the update too.