### PR TITLE
Fix ClassMetadataInterface::getAttributesMetadata return typehint

### DIFF
--- a/Mapping/ClassMetadataInterface.php
+++ b/Mapping/ClassMetadataInterface.php
@@ -83,7 +83,7 @@ interface ClassMetadataInterface
     /**
      * Gets attributes metadata. The key is the attribute name.
      *
-     * @return array The attribute name as key, an instance of AttributeMetadataInterface as value.
+     * @return AttributeMetadataInterface[] The attribute name as key, an instance of AttributeMetadataInterface as value.
      */
     public function getAttributesMetadata();
 


### PR DESCRIPTION
I think the `AttributeMetadataInterface[]` notation is applicable, even if the array has string keys ?