### PR TITLE
Re-add default message to NotFoundHttpException

### DIFF
--- a/Action/ActionUtilTrait.php
+++ b/Action/ActionUtilTrait.php
@@ -39,7 +39,7 @@ trait ActionUtilTrait
     {
         $data = $dataProvider->getItem($resourceType, $id, true);
         if (!$data) {
-            throw new NotFoundHttpException();
+            throw new NotFoundHttpException('Not Found');
         }
 
         return $data;


### PR DESCRIPTION
Re-add the default message `Not Found` into the thrown `NotFoundHttpException`, as it was the case previously when using the framework bundle `Controller::createNotFoundException()`.

Otherwise, the generated response in the api looks like : 
```json
{
    "@context": "/api/contexts/Error",
    "@type": "Error",
    "hydra:title": "An error occurred",
    "hydra:description": ""
}
```
Instead of:
```json
{
    "@context": "/api/contexts/Error",
    "@type": "Error",
    "hydra:title": "An error occurred",
    "hydra:description": "Not Found"
}
```