### PR TITLE
Fix prepend condition

### DIFF
--- a/DependencyInjection/DunglasApiExtension.php
+++ b/DependencyInjection/DunglasApiExtension.php
@@ -30,7 +30,7 @@ class DunglasApiExtension extends Extension implements PrependExtensionInterface
      */
     public function prepend(ContainerBuilder $container)
     {
-        if (null !== ($frameworkConfiguration = $container->getExtensionConfig('framework'))) {
+        if (!empty($frameworkConfiguration = $container->getExtensionConfig('framework'))) {
             if (!isset($frameworkConfiguration['serializer']) || !isset($frameworkConfiguration['serializer']['enabled'])) {
                 $container->prependExtensionConfig('framework', [
                     'serializer' => [

--- a/Tests/DependencyInjection/DunglasApiExtensionTest.php
+++ b/Tests/DependencyInjection/DunglasApiExtensionTest.php
@@ -70,7 +70,7 @@ class DunglasApiExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $containerBuilderProphecy = $this->prophesize('Symfony\Component\DependencyInjection\ContainerBuilder');
         $containerBuilderProphecy->getExtensionConfig('framework')->willReturn([])->shouldBeCalled();
-        $containerBuilderProphecy->prependExtensionConfig('framework', Argument::type('array'))->shouldBeCalled();
+        $containerBuilderProphecy->prependExtensionConfig('framework', Argument::type('array'))->shouldNotBeCalled();
         $containerBuilder = $containerBuilderProphecy->reveal();
 
         $this->extension->prepend($containerBuilder);


### PR DESCRIPTION
If we do:

```php
$container->getExtensionConfig('unknown')
```

The result will be `[]` and not `null`.