### PR TITLE
Support GroupSequence and callable for validation groups

### DIFF
--- a/Api/Resource.php
+++ b/Api/Resource.php
@@ -14,6 +14,7 @@ namespace Dunglas\ApiBundle\Api;
 use Dunglas\ApiBundle\Api\Filter\FilterInterface;
 use Dunglas\ApiBundle\Api\Operation\OperationInterface;
 use Dunglas\ApiBundle\Exception\InvalidArgumentException;
+use Symfony\Component\Validator\Constraints\GroupSequence;
 
 /**
  * {@inheritdoc}
@@ -47,7 +48,7 @@ class Resource implements ResourceInterface
      */
     private $denormalizationContext = [];
     /**
-     * @var string[]
+     * @var string[]|GroupSequence|callable
      */
     private $validationGroups;
     /**
@@ -223,9 +224,9 @@ class Resource implements ResourceInterface
     /**
      * Initializes validation groups.
      *
-     * @param array $validationGroups
+     * @param string[]|GroupSequence|callable $validationGroups
      */
-    public function initValidationGroups(array $validationGroups)
+    public function initValidationGroups($validationGroups)
     {
         $this->validationGroups = $validationGroups;
     }

--- a/Api/ResourceInterface.php
+++ b/Api/ResourceInterface.php
@@ -13,6 +13,7 @@ namespace Dunglas\ApiBundle\Api;
 
 use Dunglas\ApiBundle\Api\Filter\FilterInterface;
 use Dunglas\ApiBundle\Api\Operation\OperationInterface;
+use Symfony\Component\Validator\Constraints\GroupSequence;
 
 /**
  * An API resource.
@@ -87,7 +88,7 @@ interface ResourceInterface
     /**
      * Gets validation groups to use.
      *
-     * @return string[]|null
+     * @return string[]|GroupSequence|callable|null
      */
     public function getValidationGroups();
 

--- a/EventListener/ValidationViewListener.php
+++ b/EventListener/ValidationViewListener.php
@@ -49,7 +49,16 @@ class ValidationViewListener
             return;
         }
 
-        $violations = $this->validator->validate($event->getControllerResult(), null, $resourceType->getValidationGroups());
+        $data = $event->getControllerResult();
+        $validationGroups = $resourceType->getValidationGroups();
+
+        if (is_callable($validationGroups)) {
+            $validationGroups = call_user_func_array($validationGroups, [
+                $data,
+            ]);
+        }
+
+        $violations = $this->validator->validate($data, null, $validationGroups);
         if (0 !== count($violations)) {
             throw new ValidationException($violations);
         }

--- a/Mapping/Loader/ValidatorMetadataLoader.php
+++ b/Mapping/Loader/ValidatorMetadataLoader.php
@@ -65,6 +65,10 @@ class ValidatorMetadataLoader implements LoaderInterface
                     }
                 } else {
                     foreach ($validationGroups as $validationGroup) {
+                        if (!is_string($validationGroup)) {
+                            continue;
+                        }
+
                         foreach ($propertyMetadata->findConstraints($validationGroup) as $constraint) {
                             if ($this->isRequired($constraint)) {
                                 $attributeMetadata = $attributeMetadata->withRequired(true);

--- a/Tests/EventListener/ValidationViewListenerTest.php
+++ b/Tests/EventListener/ValidationViewListenerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the DunglasApiBundle package.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Dunglas\ApiBundle\Tests\EventListener;
+
+use Dunglas\ApiBundle\EventListener\ValidationViewListener;
+use Dunglas\ApiBundle\Tests\Fixtures\DummyEntity;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * @author Teoh Han Hui <teohhanhui@gmail.com>
+ */
+class ValidationViewListenerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testValidationGroupsFromCallable()
+    {
+        $data = new DummyEntity();
+        $expectedValidationGroups = ['a', 'b', 'c'];
+
+        $validationGroupsResolverProphecy = $this->prophesize('Dunglas\ApiBundle\Tests\Mock\ValidationGroupsResolverInterface');
+        $validationGroupsResolverProphecy->getValidationGroups($data)->willReturn($expectedValidationGroups)->shouldBeCalled();
+        $validationGroupsResolver = $validationGroupsResolverProphecy->reveal();
+
+        $validatorProphecy = $this->prophesize('Symfony\Component\Validator\Validator\ValidatorInterface');
+        $validatorProphecy->validate($data, null, $expectedValidationGroups)->shouldBeCalled();
+        $validator = $validatorProphecy->reveal();
+
+        $resourceTypeProphecy = $this->prophesize('Dunglas\ApiBundle\Api\ResourceInterface');
+        $resourceTypeProphecy->getValidationGroups()->willReturn([$validationGroupsResolver, 'getValidationGroups'])->shouldBeCalled();
+        $resourceType = $resourceTypeProphecy->reveal();
+
+        $kernel = $this->prophesize('Symfony\Component\HttpKernel\HttpKernelInterface')->reveal();
+        $request = new Request([], [], [
+            '_resource_type' => $resourceType,
+        ]);
+        $request->setMethod(Request::METHOD_POST);
+        $event = new GetResponseForControllerResultEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, $data);
+
+        $validationViewListener = new ValidationViewListener($validator);
+        $validationViewListener->onKernelView($event);
+    }
+}

--- a/Tests/Mock/ValidationGroupsResolverInterface.php
+++ b/Tests/Mock/ValidationGroupsResolverInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the DunglasApiBundle package.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Dunglas\ApiBundle\Tests\Mock;
+
+use Symfony\Component\Validator\Constraints\GroupSequence;
+
+/**
+ * @author Teoh Han Hui <teohhanhui@gmail.com>
+ */
+interface ValidationGroupsResolverInterface
+{
+    /**
+     * Gets validation groups for the provided data.
+     *
+     * @param mixed $data
+     *
+     * @return string[]|GroupSequence
+     */
+    public function getValidationGroups($data);
+}


### PR DESCRIPTION
Continuing from #250...

I've found out that [group sequence providers](http://symfony.com/doc/current/book/validation.html#group-sequence-providers) do not handle cascade well:

symfony/symfony#3622
symfony/symfony#9650
symfony/symfony#11880
symfony/symfony#15666

According to [JSR303](http://beanvalidation.org/1.0/spec/#constraintdeclarationvalidationprocess-validationroutine-graphvalidation):
> Note however that the Default group sequence overriding is local to the class it is defined on and is not propagated to the associated objects.

(Also see Example 3.12 under the same section)

So a callback to determine the validation groups seems to be the solution...