### PR TITLE
Fixed issue with join being inner instead of left join

### DIFF
--- a/Doctrine/Orm/DataProvider.php
+++ b/Doctrine/Orm/DataProvider.php
@@ -127,7 +127,7 @@ class DataProvider implements DataProviderInterface
             $mapping = $classMetaData->associationMappings[$association];
 
             if (ClassMetadataInfo::FETCH_EAGER === $mapping['fetch']) {
-                $queryBuilder->join('o.'.$association, 'a'.$i);
+                $queryBuilder->leftJoin('o.'.$association, 'a'.$i);
                 $queryBuilder->addSelect('a'.$i);
             }
         }


### PR DESCRIPTION
As mentioned before. If there are no items in the target table of the relation, then these items won't appear in the collection (try disabling the `$fetchJoinCollection` parameter in the Doctrine paginator, and you'll see that the result won't be the expected result).