### PR TITLE
Better DateTime invalid format handling.

### DIFF
--- a/JsonLd/Serializer/DateTimeNormalizer.php
+++ b/JsonLd/Serializer/DateTimeNormalizer.php
@@ -11,6 +11,7 @@
 
 namespace Dunglas\ApiBundle\JsonLd\Serializer;
 
+use Dunglas\ApiBundle\Exception\DeserializationException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -53,6 +54,10 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface
      */
     public function denormalize($data, $class, $format = null, array $context = [])
     {
-        return new \DateTime($data);
+        try {
+            return new \DateTime($data);
+        } catch (\Exception $exception) {
+            throw new DeserializationException($exception->getMessage(), $exception->getCode(), $exception);
+        }
     }
 }

--- a/Tests/Behat/TestBundle/Entity/Dummy.php
+++ b/Tests/Behat/TestBundle/Entity/Dummy.php
@@ -129,7 +129,7 @@ class Dummy
     {
     }
 
-    public function setDummyDate(\DateTime $dummyDate)
+    public function setDummyDate(\DateTime $dummyDate = null)
     {
         $this->dummyDate = $dummyDate;
     }

--- a/features/invalid_data.feature
+++ b/features/invalid_data.feature
@@ -32,6 +32,18 @@ Feature: Handle properly invalid data submitted to the API
     }
     """
 
+  Scenario: Ignore invalid dates
+    When I send a "POST" request to "/dummies" with body:
+    """
+    {
+      "name": "Invalid date",
+      "dummyDate": "Invalid"
+    }
+    """
+    Then the response status code should be 400
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json"
+
   @dropSchema
   Scenario: Send non-array data when an array is expected
     When I send a "POST" request to "/dummies" with body:


### PR DESCRIPTION
Need a mention in the doc explaining that you **must** always allow `null` values in `\DateTime` typehints and use a validator assertion if `null` values must thrown an error.