### PR TITLE
Fix IriConverterInterface return value

### DIFF
--- a/Api/IriConverterInterface.php
+++ b/Api/IriConverterInterface.php
@@ -27,7 +27,7 @@ interface IriConverterInterface
      * @param string $iri
      * @param bool   $fetchData
      *
-     * @return object
+     * @return object|null
      *
      * @throws InvalidArgumentException
      */


### PR DESCRIPTION
The DataProvider can return `null`, (specified in [`DataProviderInterface`](https://github.com/dunglas/DunglasApiBundle/blob/master/Model/DataProviderInterface.php#L30)), so it's only logical that the [`IriConverterInterface`](https://github.com/dunglas/DunglasApiBundle/blob/master/Api/IriConverterInterface.php#L30) does the same. Also from the current implementation of [`SearchFilter::getFilterValueFromUrl()`](https://github.com/dunglas/DunglasApiBundle/blob/master/Doctrine/Orm/Filter/SearchFilter.php#L190-L192) rely on this result.

Can also be merged back to the 1.0.