### PR TITLE
Increment version for branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "1.0-dev"
+      "dev-master": "2.0.x-dev"
     }
   }
 }


### PR DESCRIPTION
This prevents people from using `1.0@dev` or `dev-1.0` in order to fetch content from the `1.0` branch.