### PR TITLE
issues #284 add "Symfony constraints in /apidoc" feature

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -61,6 +61,7 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->booleanNode('enable_apidoc_symfony_constraints')->defaultValue(false)->info('Enable display of symfony:constraints in /apidoc end point.')->end()
             ->end()
         ;
 

--- a/DependencyInjection/DunglasApiExtension.php
+++ b/DependencyInjection/DunglasApiExtension.php
@@ -51,6 +51,7 @@ class DunglasApiExtension extends Extension implements PrependExtensionInterface
 
         $container->setParameter('api.title', $config['title']);
         $container->setParameter('api.description', $config['description']);
+        $container->setParameter('api.enable_apidoc_symfony_constraints', $config['enable_apidoc_symfony_constraints']);
         $container->setParameter('api.collection.filter_name.order', $config['collection']['filter_name']['order']);
         $container->setParameter('api.collection.order', $config['collection']['order']);
         $container->setParameter('api.collection.pagination.page_parameter_name', $config['collection']['pagination']['page_parameter_name']);

--- a/Hydra/ApiDocumentationBuilder.php
+++ b/Hydra/ApiDocumentationBuilder.php
@@ -47,6 +47,11 @@ class ApiDocumentationBuilder implements ApiDocumentationBuilderInterface
     private $description;
 
     /**
+     * @var bool
+     */
+    private $enableSymfonyConstraints;
+
+    /**
      * @param ResourceCollectionInterface   $resourceCollection
      * @param ContextBuilder                $contextBuilder
      * @param RouterInterface               $router
@@ -60,7 +65,8 @@ class ApiDocumentationBuilder implements ApiDocumentationBuilderInterface
         RouterInterface $router,
         ClassMetadataFactoryInterface $classMetadataFactory,
         $title,
-        $description
+        $description,
+        $enableSymfonyConstraints
     ) {
         $this->resourceCollection = $resourceCollection;
         $this->contextBuilder = $contextBuilder;
@@ -68,6 +74,7 @@ class ApiDocumentationBuilder implements ApiDocumentationBuilderInterface
         $this->classMetadataFactory = $classMetadataFactory;
         $this->title = $title;
         $this->description = $description;
+        $this->enableSymfonyConstraints = $enableSymfonyConstraints;
     }
 
     /**
@@ -153,6 +160,10 @@ class ApiDocumentationBuilder implements ApiDocumentationBuilderInterface
 
                 if ($description = $attributeMetadata->getDescription()) {
                     $property['hydra:description'] = $description;
+                }
+
+                if ($this->enableSymfonyConstraints) {
+                    $property['symfony:constraints'] = $attributeMetadata->getSymfonyConstraints();
                 }
 
                 $properties[] = $property;

--- a/Mapping/AttributeMetadata.php
+++ b/Mapping/AttributeMetadata.php
@@ -100,6 +100,14 @@ class AttributeMetadata implements AttributeMetadataInterface
      *           {@link isIdentifier()} instead.
      */
     public $identifier;
+    /**
+     * @var string|null
+     *
+     * @internal This property is public in order to reduce the size of the
+     *           class' serialized representation. Do not access it. Use
+     *           {@link getSymfonyConstraints()} instead.
+     */
+    public $symfonyConstraints;
 
     /**
      * @param string    $name
@@ -245,6 +253,22 @@ class AttributeMetadata implements AttributeMetadataInterface
     public function getIri()
     {
         return $this->iri;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setSymfonyConstraints(array $symfonyConstraints)
+    {
+        $this->symfonyConstraints = $symfonyConstraints;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSymfonyConstraints()
+    {
+        return $this->symfonyConstraints;
     }
 
     /**

--- a/Resources/config/hydra.xml
+++ b/Resources/config/hydra.xml
@@ -12,6 +12,7 @@
             <argument type="service" id="api.mapping.class_metadata_factory" />
             <argument>%api.title%</argument>
             <argument>%api.description%</argument>
+            <argument>%api.enable_apidoc_symfony_constraints%</argument>
         </service>
 
         <!-- Event listeners -->

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -38,6 +38,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 ],
             ],
         ],
+        'enable_apidoc_symfony_constraints' => false,
     ];
 
     public function testDefaultConfig()

--- a/Tests/DependencyInjection/DunglasApiExtensionTest.php
+++ b/Tests/DependencyInjection/DunglasApiExtensionTest.php
@@ -179,6 +179,7 @@ class DunglasApiExtensionTest extends \PHPUnit_Framework_TestCase
         $containerBuilderProphecy->setDefinition('api.hydra.normalizer.collection', $definitionArgument)->shouldBeCalled();
         $containerBuilderProphecy->setDefinition('api.hydra.normalizer.constraint_violation_list', $definitionArgument)->shouldBeCalled();
         $containerBuilderProphecy->setDefinition('api.hydra.normalizer.error', $definitionArgument)->shouldBeCalled();
+        $containerBuilderProphecy->setParameter('api.enable_apidoc_symfony_constraints', false)->shouldBeCalled();
 
         return $containerBuilderProphecy;
     }


### PR DESCRIPTION
Enable display of Symfony constraints in /apidoc route.

This feature is optional, to enable it, just set :
```yaml
dunglas_api:
    …
    enable_apidoc_symfony_constraints: true
```