### PR TITLE
Add an option to totally disable doctrine support

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -40,6 +40,7 @@ class Configuration implements ConfigurationInterface
                     ->prototype('scalar')->end()
                 ->end()
                 ->scalarNode('cache')->defaultFalse()->info('The caching service to use. Set to "dunglas_api.mapping.cache.apc" to enable APC metadata caching.')->end()
+                ->booleanNode('enable_doctrine_orm')->defaultValue(true)->info('Enable the Doctrine ORM integration.')->end()
                 ->booleanNode('enable_fos_user')->defaultValue(false)->info('Enable the FOSUserBundle integration.')->end()
                 ->arrayNode('collection')
                     ->addDefaultsIfNotSet()

--- a/DependencyInjection/DunglasApiExtension.php
+++ b/DependencyInjection/DunglasApiExtension.php
@@ -66,7 +66,10 @@ class DunglasApiExtension extends Extension implements PrependExtensionInterface
         $loader->load('api.xml');
         $loader->load('property_info.xml');
         $loader->load('mapping.xml');
-        $loader->load('doctrine_orm.xml');
+
+        if ($config['enable_doctrine_orm']) {
+            $loader->load('doctrine_orm.xml');
+        }
 
         $this->enableJsonLd($container, $loader);
 

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -24,6 +24,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         'description' => 'description',
         'supported_formats' => ['jsonld'],
         'cache' => false,
+        'enable_doctrine_orm' => true,
         'enable_fos_user' => false,
         'collection' => [
             'filter_name' => [


### PR DESCRIPTION
For now it's not possible to use Api Platform without doctrine easily as the `doctrine` service is used to declare several services.