### PR TITLE
Add an option to totally disable doctrine support

### DIFF
--- a/DependencyInjection/Compiler/DataProviderPass.php
+++ b/DependencyInjection/Compiler/DataProviderPass.php
@@ -14,6 +14,7 @@ namespace Dunglas\ApiBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
+use Dunglas\ApiBundle\Exception\RuntimeException;
 
 /**
  * Injects data managers in the chain.
@@ -27,8 +28,13 @@ class DataProviderPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        $taggedServices = $container->findTaggedServiceIds('api.data_provider');
+        if (0 === count($taggedServices)) {
+            throw new RuntimeException('No DataProvider found. Did you forget to tag your own data provider?');
+        }
+
         $sortedServices = [];
-        foreach ($container->findTaggedServiceIds('api.data_provider') as $serviceId => $tags) {
+        foreach ($taggedServices as $serviceId => $tags) {
             foreach ($tags as $tag) {
                 $priority = isset($tag['priority']) ? $tag['priority'] : 0;
                 $sortedServices[$priority][] = new Reference($serviceId);

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -29,11 +29,15 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('dunglas_api');
 
+        // We chack if symfony's doctrine bridge is enabled or not to choose the defaultValue for `enable_doctrine_orm`.
+        $enableDoctrineOrm = interface_exists('\Symfony\Bridge\Doctrine\RegistryInterface');
+
         $rootNode
             ->children()
                 ->scalarNode('title')->cannotBeEmpty()->isRequired()->info('The title of the API.')->end()
                 ->scalarNode('description')->cannotBeEmpty()->isRequired()->info('The description of the API.')->end()
                 ->scalarNode('cache')->defaultFalse()->info('The caching service to use. Set to "dunglas_api.mapping.cache.apc" to enable APC metadata caching.')->end()
+                ->booleanNode('enable_doctrine_orm')->defaultValue($enableDoctrineOrm)->info('Enable the Doctrine ORM integration.')->end()
                 ->booleanNode('enable_fos_user')->defaultValue(false)->info('Enable the FOSUserBundle integration.')->end()
                 ->arrayNode('collection')
                     ->addDefaultsIfNotSet()

--- a/Resources/config/doctrine_orm.xml
+++ b/Resources/config/doctrine_orm.xml
@@ -47,6 +47,10 @@
         <service id="api.mapping.loaders.doctrine_identifier" class="Dunglas\ApiBundle\Mapping\Loader\DoctrineIdentifierLoader" public="false">
             <argument type="service" id="doctrine" />
         </service>
+
+        <service id="api.property_info.doctrine_extractor" class="PropertyInfo\Extractors\DoctrineExtractor" public="false">
+            <argument type="service" id="api.doctrine.metadata_factory" />
+        </service>
     </services>
 
 </container>

--- a/Resources/config/mapping.xml
+++ b/Resources/config/mapping.xml
@@ -35,7 +35,6 @@
                 <argument type="service" id="api.mapping.loaders.attributes" />
                 <argument type="service" id="api.mapping.loaders.validator_metadata" />
                 <argument type="service" id="api.mapping.loaders.phpdoc" />
-                <argument type="service" id="api.mapping.loaders.doctrine_identifier" on-invalid="ignore" />
                 <argument type="service" id="api.mapping.loaders.annotation" />
             </argument>
         </service>

--- a/Resources/config/property_info.xml
+++ b/Resources/config/property_info.xml
@@ -7,17 +7,12 @@
     <services>
         <service id="api.property_info" class="PropertyInfo\PropertyInfo" public="false">
             <argument type="collection">
-                <argument type="service" id="api.property_info.doctrine_extractor" />
                 <argument type="service" id="api.property_info.setter_extractor" />
                 <argument type="service" id="api.property_info.php_doc_extractor" />
             </argument>
             <argument type="collection">
                 <argument type="service" id="api.property_info.php_doc_extractor" />
             </argument>
-        </service>
-
-        <service id="api.property_info.doctrine_extractor" class="PropertyInfo\Extractors\DoctrineExtractor" public="false">
-            <argument type="service" id="api.doctrine.metadata_factory" />
         </service>
 
         <service id="api.property_info.php_doc_extractor" class="PropertyInfo\Extractors\PhpDocExtractor" public="false" />

--- a/Tests/DependencyInjection/Compiler/DataProviderPassTest.php
+++ b/Tests/DependencyInjection/Compiler/DataProviderPassTest.php
@@ -36,4 +36,21 @@ class DataProviderPassTest extends \PHPUnit_Framework_TestCase
 
         $dataProviderPass->process($containerBuilder);
     }
+
+    /**
+     * @expectedException \Dunglas\ApiBundle\Exception\RuntimeException
+     * @expectedExceptionMessage No DataProvider found. Did you forget to tag your own data provider?
+     */
+    public function testProcessWithoutTaggedServices()
+    {
+        $dataProviderPass = new DataProviderPass();
+
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface', $dataProviderPass);
+
+        $containerBuilderProphecy = $this->prophesize('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $containerBuilderProphecy->findTaggedServiceIds('api.data_provider')->willReturn([])->shouldBeCalled();
+        $containerBuilder = $containerBuilderProphecy->reveal();
+
+        $dataProviderPass->process($containerBuilder);
+    }
 }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -23,6 +23,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         'title' => 'title',
         'description' => 'description',
         'cache' => false,
+        'enable_doctrine_orm' => true,
         'enable_fos_user' => false,
         'collection' => [
             'filter_name' => [

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,7 @@
     "symfony/framework-bundle": "~2.6|~3.0",
     "symfony/proxy-manager-bridge": "~2.3",
     "ocramius/proxy-manager": "~1.0",
-    "doctrine/orm": "~2.2,>=2.2.3",
     "doctrine/inflector": "~1.0",
-    "doctrine/doctrine-bundle": "~1.2",
     "dunglas/php-property-info": "~0.2",
     "phpdocumentor/reflection": "^1.0.7"
   },
@@ -34,9 +32,12 @@
     "behat/mink-browserkit-driver": "~1.1",
     "behatch/contexts": "dev-master#eef7ab39ca896796bf3ba25a0fa5a95f15276eb7",
     "symfony/finder": "~2.3",
-    "phpunit/phpunit": "~4.6"
+    "phpunit/phpunit": "~4.6",
+    "doctrine/orm": "~2.2,>=2.2.3",
+    "doctrine/doctrine-bundle": "~1.2"
   },
   "suggest": {
+    "doctrine/doctrine-bundle": "To use the Doctrine ORM bridge.",
     "friendsofsymfony/user-bundle": "To use the FOSUserBundle bridge."
   },
   "autoload": {


### PR DESCRIPTION
For now it's not possible to use Api Platform without doctrine easily as the doctrine service is used to declare several services.