### PR TITLE
Cache paginator iterator

### DIFF
--- a/Doctrine/Orm/Paginator.php
+++ b/Doctrine/Orm/Paginator.php
@@ -42,6 +42,11 @@ class Paginator implements \IteratorAggregate, PaginatorInterface
      */
     private $totalItems;
 
+    /**
+     * @var \Traversable
+     */
+    private $iterator;
+
     public function __construct(DoctrineOrmPaginator $paginator)
     {
         $this->paginator = $paginator;
@@ -88,7 +93,11 @@ class Paginator implements \IteratorAggregate, PaginatorInterface
      */
     public function getIterator()
     {
-        return $this->paginator->getIterator();
+        if (null === $this->iterator) {
+            $this->iterator = $this->paginator->getIterator();
+        }
+
+        return $this->iterator;
     }
 
     /**

--- a/Tests/Doctrine/Orm/PaginatorTest.php
+++ b/Tests/Doctrine/Orm/PaginatorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the DunglasApiBundle package.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Doctrine\Orm;
+
+use Dunglas\ApiBundle\Doctrine\Orm\Paginator;
+
+class PaginatorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider initializeProvider
+     */
+    public function testInitialize($firstResult, $maxResults, $totalItems, $currentPage, $lastPage)
+    {
+        $paginator = $this->getPaginator($firstResult, $maxResults, $totalItems);
+
+        $this->assertEquals($currentPage, $paginator->getCurrentPage());
+        $this->assertEquals($lastPage, $paginator->getLastPage());
+        $this->assertEquals($maxResults, $paginator->getItemsPerPage());
+    }
+
+    public function testGetIterator()
+    {
+        $paginator = $this->getPaginator();
+
+        $this->assertSame($paginator->getIterator(), $paginator->getIterator(), 'Iterator should be cached');
+    }
+
+    public function getPaginator($firstResult = 1, $maxResults = 15, $totalItems = 42)
+    {
+        $query = $this->prophesize('Dunglas\ApiBundle\Tests\Fixtures\Query');
+        $query->getFirstResult()->willReturn($firstResult)->shouldBeCalled();
+        $query->getMaxResults()->willReturn($maxResults)->shouldBeCalled();
+
+        $doctrinePaginator = $this->prophesize('Doctrine\ORM\Tools\Pagination\Paginator');
+
+        $doctrinePaginator->getQuery()->willReturn($query->reveal())->shouldBeCalled();
+        $doctrinePaginator->count()->willReturn($totalItems)->shouldBeCalled();
+
+        $doctrinePaginator->getIterator()->will(function () {
+            return new \ArrayIterator();
+        });
+
+        return new Paginator($doctrinePaginator->reveal());
+    }
+
+    public function initializeProvider()
+    {
+        return [
+            'First of three pages of 15 items each' => [0, 15, 42, 1, 3],
+            'Second of two pages of 10 items each' => [10, 10, 20, 2, 2],
+        ];
+    }
+}

--- a/Tests/Fixtures/Query.php
+++ b/Tests/Fixtures/Query.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Dunglas\ApiBundle\Tests\Fixtures;
+
+/**
+ * Replace Doctrine\ORM\Query in tests because it cannot be mocked.
+ */
+class Query
+{
+    public function getFirstResult()
+    {
+    }
+    public function getMaxResults()
+    {
+    }
+}


### PR DESCRIPTION
When we use paginated data in several places (through events for instance), queries are re-issued every time we iterate on `DataEvent::getData()`.
It would be nice if the iterators were cached.