### PR TITLE
Add Symfony 3.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,14 @@ matrix:
     allow_failures:
         - php: nightly
     fast_finish: true
+    include:
+        - php: 5.6
+          env: DEPENDENCIES=dev
 
 before_script:
     - composer self-update
-    - if [[ "$TRAVIS_PHP_VERSION" = "5.6" ]]; then wget http://get.sensiolabs.org/php-cs-fixer.phar; fi;
+    - if [ "$TRAVIS_PHP_VERSION" = "5.6" ] && [ "$DEPENDENCIES" != "dev" ]; then wget http://get.sensiolabs.org/php-cs-fixer.phar; fi;
+    - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
 
 install:
     - composer install
@@ -27,4 +31,4 @@ install:
 script:
     - vendor/bin/behat
     - vendor/bin/phpunit
-    - if [[ "$TRAVIS_PHP_VERSION" = "5.6" ]]; then php php-cs-fixer.phar fix --no-interaction --dry-run --diff -vvv; fi;
+    - if [ "$TRAVIS_PHP_VERSION" = "5.6" ] && [ "$DEPENDENCIES" != "dev" ]; then php php-cs-fixer.phar fix --no-interaction --dry-run --diff -vvv; fi;

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "symfony/serializer": "^2.7.2|~3.0",
     "symfony/validator": "~2.5|~3.0",
     "symfony/framework-bundle": "~2.6|~3.0",
-    "symfony/proxy-manager-bridge": "~2.3",
+    "symfony/proxy-manager-bridge": "~2.3|~3.0",
     "ocramius/proxy-manager": "~1.0",
     "doctrine/inflector": "~1.0",
     "dunglas/php-property-info": "~0.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

This PR adds symfony 3.0 support by changing the constraint of ``symfony/proxy-manager-bridge`` and adding a new build to the ``.travis.yml``.