### PR TITLE
Fix "0" value in SearchFilter

### DIFF
--- a/Doctrine/Orm/Filter/SearchFilter.php
+++ b/Doctrine/Orm/Filter/SearchFilter.php
@@ -89,9 +89,9 @@ class SearchFilter extends AbstractFilter
     {
         foreach ($this->extractProperties($request) as $property => $value) {
             if (
-                empty($value) ||
                 !$this->isPropertyEnabled($property) ||
-                !$this->isPropertyMapped($property, $resource, true)
+                !$this->isPropertyMapped($property, $resource, true) ||
+                null === $value
             ) {
                 continue;
             }


### PR DESCRIPTION
Currently we are unable to filter by 0 (false) value, it has already been fixed in master https://github.com/dunglas/DunglasApiBundle/blob/master/Doctrine/Orm/Filter/SearchFilter.php#L102