### PR TITLE
Remove the usage of NumericNodeDefinition::cannotBeEmpty()

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -61,7 +61,7 @@ class Configuration implements ConfigurationInterface
                                 ->arrayNode('items_per_page')
                                     ->addDefaultsIfNotSet()
                                     ->children()
-                                        ->integerNode('default')->min(1)->defaultValue(30)->cannotBeEmpty()->info('The default number of items perm page in collections.')->end()
+                                        ->integerNode('default')->min(1)->defaultValue(30)->info('The default number of items perm page in collections.')->end()
                                         ->booleanNode('client_can_change')->defaultValue(false)->info('Allow the client to change the number of elements by page.')->end()
                                         ->scalarNode('parameter')->defaultValue('itemsPerPage')->info('The name of the parameter to change the number of elements by page client side.')->end()
                                     ->end()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

``NumericNodeDefinition::cannotBeEmpty()`` is deprecated since symfony 2.8. See https://github.com/symfony/symfony/pull/15170