### PR TITLE
Escape backslashes else it's considered as unicode character

### DIFF
--- a/Tests/Behat/TestBundle/EventListener/XmlResponderViewListener.php
+++ b/Tests/Behat/TestBundle/EventListener/XmlResponderViewListener.php
@@ -72,8 +72,12 @@ class XmlResponderViewListener
         }
 
         $resourceType = $request->attributes->get('_resource_type');
+
+        $context = $resourceType->getNormalizationContext();
+        unset($context['resource']);
+
         $response = new Response(
-            $this->serializer->serialize($controllerResult, self::FORMAT, $resourceType->getNormalizationContext()),
+            $this->serializer->serialize($controllerResult, self::FORMAT, $context),
             $status,
             ['Content-Type' => 'application/xml']
         );

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -55,13 +55,11 @@ class FeatureContext implements Context, SnippetAcceptingContext
     /**
      * Sets the default Accept HTTP header to the JSON-LD mime type.
      *
-     * Contains a workaround for BrowserKit (HTTP_Accept instead of Accept).
-     *
      * @BeforeScenario
      */
     public function acceptJsonLd()
     {
-        $this->request->setHttpHeader('HTTP_Accept', 'application/ld+json');
+        $this->request->setHttpHeader('Accept', 'application/ld+json');
     }
 
     /**

--- a/features/content_negotiation.feature
+++ b/features/content_negotiation.feature
@@ -5,7 +5,7 @@ Feature: Content Negotiation support
 
   @createSchema
   Scenario: Post an XML body
-    When I add "HTTP_Accept" header equal to "application/xml"
+    When I add "Accept" header equal to "application/xml"
     And I send a "POST" request to "/dummies" with body:
     """
     <root>
@@ -21,7 +21,7 @@ Feature: Content Negotiation support
 
   @dropSchema
   Scenario: Requesting an unknown format should return JSON-LD
-    When I add "HTTP_Accept" header equal to "text/plain"
+    When I add "Accept" header equal to "text/plain"
     And I send a "GET" request to "/dummies/1"
     Then the header "Content-Type" should be equal to "application/ld+json"
     And the JSON should be equal to:

--- a/features/fixtures/TestApp/config/config.yml
+++ b/features/fixtures/TestApp/config/config.yml
@@ -45,11 +45,11 @@ fos_user:
     firewall_name:    api
     service:
         user_manager: api.user_manager
-    user_class:       "Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\User"
+    user_class:       'Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\User'
 
 services:
     api.user_manager:
-        class: "Dunglas\ApiBundle\Tests\Behat\TestBundle\Manager\UserManager"
+        class: 'Dunglas\ApiBundle\Tests\Behat\TestBundle\Manager\UserManager'
         arguments:
             -  @security.encoder_factory
             -  @fos_user.util.username_canonicalizer
@@ -58,13 +58,13 @@ services:
             -  %fos_user.model.user.class%
 
     fos_user.mailer.default:
-        class: "Dunglas\ApiBundle\Tests\Mock\MailerMock"
+        class: 'Dunglas\ApiBundle\Tests\Mock\MailerMock'
 
     api.name_converter:
-        class: "Dunglas\ApiBundle\Tests\Behat\TestBundle\Serializer\\NameConverter\CustomConverter"
+        class: 'Dunglas\ApiBundle\Tests\Behat\TestBundle\Serializer\NameConverter\CustomConverter'
 
     xml_responder_view_listener:
-        class: "Dunglas\ApiBundle\Tests\Behat\TestBundle\EventListener\XmlResponderViewListener"
+        class: 'Dunglas\ApiBundle\Tests\Behat\TestBundle\EventListener\XmlResponderViewListener'
         arguments:
             - @api.serializer
         tags:
@@ -72,7 +72,7 @@ services:
 
     user:
         parent:                      "api.resource"
-        arguments:                   [ "Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\User" ]
+        arguments:                   [ 'Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\User' ]
         calls:
                                      - method:    "initNormalizationContext"
                                        arguments: [ { groups: [ "user", "user-read" ] } ]
@@ -98,7 +98,7 @@ services:
 
     my_dummy_resource:
         parent:                      "api.resource"
-        arguments:                   [ "Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\Dummy" ]
+        arguments:                   [ 'Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\Dummy' ]
         calls:
                                      - method:    "initFilters"
                                        arguments: [ [ "@my_dummy_resource.search_filter", "@my_dummy_resource.order_filter", "@my_dummy_resource.date_filter" ] ]
@@ -106,23 +106,23 @@ services:
 
     my_related_dummy_resource:
         parent:                     "api.resource"
-        arguments:                  [ "Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\RelatedDummy" ]
+        arguments:                  [ 'Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\RelatedDummy' ]
         tags:                       [ { name: "api.resource" } ]
 
     my_relation_embedder_resource.item_operation.get:
-        class:                      "Dunglas\ApiBundle\Api\Operation\Operation"
+        class:                      'Dunglas\ApiBundle\Api\Operation\Operation'
         public:                     false
         factory:                    [ "@api.operation_factory", "createItemOperation" ]
         arguments:                  [ "@my_relation_embedder_resource", "GET" ]
 
     my_relation_embedder_resource.item_operation.put:
-        class:                      "Dunglas\ApiBundle\Api\Operation\Operation"
+        class:                      'Dunglas\ApiBundle\Api\Operation\Operation'
         public:                     false
         factory:                    [ "@api.operation_factory", "createItemOperation" ]
         arguments:                  [ "@my_relation_embedder_resource", "PUT" ]
 
     my_relation_embedder_resource.item_operation.custom_get:
-        class:                      "Dunglas\ApiBundle\Api\Operation\Operation"
+        class:                      'Dunglas\ApiBundle\Api\Operation\Operation'
         public:                     false
         factory:                    [ "@api.operation_factory", "createItemOperation" ]
         arguments:
@@ -138,7 +138,7 @@ services:
 
     my_relation_embedder_resource:
         parent:                     "api.resource"
-        arguments:                  [ "Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\RelationEmbedder" ]
+        arguments:                  [ 'Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\RelationEmbedder' ]
         calls:
                                     - method:    "initNormalizationContext"
                                       arguments:
@@ -156,7 +156,7 @@ services:
 
     my_abstract_dummy_resource:
         parent:                      "api.resource"
-        arguments:                   [ "Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\AbstractDummy" ]
+        arguments:                   [ 'Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\AbstractDummy' ]
         calls:
                                      - method:    "initFilters"
                                        arguments: [ [ "@my_dummy_resource.search_filter", "@my_dummy_resource.order_filter", "@my_dummy_resource.date_filter" ] ]
@@ -164,22 +164,22 @@ services:
 
     my_concrete_dummy_resource:
         parent:                      "api.resource"
-        arguments:                   [ "Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\ConcreteDummy" ]
+        arguments:                   [ 'Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\ConcreteDummy' ]
         tags:                        [ { name: "api.resource" } ]
 
     custom_resource:
         parent:                     "api.resource"
-        class:                      "Dunglas\ApiBundle\Tests\Behat\TestBundle\Api\CustomResource"
+        class:                      'Dunglas\ApiBundle\Tests\Behat\TestBundle\Api\CustomResource'
         tags:                       [ { name: "api.resource" } ]
 
     third_level_resource:
         parent:                     "api.resource"
-        arguments:                  [ "Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\ThirdLevel" ]
+        arguments:                  [ 'Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\ThirdLevel' ]
         tags:                       [ { name: "api.resource" } ]
 
     circular_reference_resource:
         parent:                     "api.resource"
-        arguments:                  [ "Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\CircularReference" ]
+        arguments:                  [ 'Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\CircularReference' ]
         calls:
                                     - method:    "initNormalizationContext"
                                       arguments:
@@ -188,17 +188,17 @@ services:
 
     custom_identifier_resource:
         parent:                     "api.resource"
-        arguments:                  [ "Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\CustomIdentifierDummy" ]
+        arguments:                  [ 'Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\CustomIdentifierDummy' ]
         tags:                       [ { name: "api.resource" } ]
 
     custom_writable_identifier_resource:
         parent:                     "api.resource"
-        arguments:                  [ "Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\CustomWritableIdentifierDummy" ]
+        arguments:                  [ 'Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\CustomWritableIdentifierDummy' ]
         tags:                       [ { name: "api.resource" } ]
 
     custom_normalized_resource:
         parent:                     "api.resource"
-        arguments:                  [ "Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\CustomNormalizedDummy" ]
+        arguments:                  [ 'Dunglas\ApiBundle\Tests\Behat\TestBundle\Entity\CustomNormalizedDummy' ]
         calls:
                                     - method:    "initNormalizationContext"
                                       arguments:

--- a/features/fixtures/TestApp/config/security.yml
+++ b/features/fixtures/TestApp/config/security.yml
@@ -1,6 +1,6 @@
 security:
     encoders:
-        FOS\UserBundle\Model\UserInterface: bcrypt
+        FOS\UserBundle\Model\UserInterface: plaintext
 
     providers:
         fos_userbundle:


### PR DESCRIPTION
- [x] Fixes unit tests (escaping class names)
- [x] Fixes Behat tests (mainly due to the `Accept` header now correctly passed)
- [x] Fixes PHP7 exception