### PR TITLE
Ability to set route requirements, and define which route should be used for @id generation

### DIFF
--- a/Api/IriConverter.php
+++ b/Api/IriConverter.php
@@ -141,6 +141,18 @@ class IriConverter implements IriConverterInterface
             return $this->routeCache[$resource][$key];
         }
 
+        if ($resource instanceof RoutedResourceInterface) {
+            $method    = 'get' . ucfirst($key);
+            $routeName = $resource->$method();
+            if ($routeName) {
+                $data                        = $this->routeCache[$resource];
+                $data[$key]                  = $routeName;
+                $this->routeCache[$resource] = $data;
+
+                return $data[$key];
+            }
+        }
+
         $operations = 'item' === $prefix ? $resource->getItemOperations() : $resource->getCollectionOperations();
         foreach ($operations as $operation) {
             $methods = $operation->getRoute()->getMethods();

--- a/Api/Operation/OperationFactory.php
+++ b/Api/Operation/OperationFactory.php
@@ -39,6 +39,7 @@ class OperationFactory
      * @param null              $controller
      * @param null              $routeName
      * @param array             $context
+     * @param array             $requirements
      *
      * @return Operation
      */
@@ -48,9 +49,10 @@ class OperationFactory
         $path = null,
         $controller = null,
         $routeName = null,
-        array $context = []
+        array $context = [],
+        $requirements = []
     ) {
-        return $this->createOperation($resource, true, $methods, $path, $controller, $routeName, $context);
+        return $this->createOperation($resource, true, $methods, $path, $controller, $routeName, $context, $requirements);
     }
 
     /**
@@ -62,6 +64,7 @@ class OperationFactory
      * @param null              $controller
      * @param null              $routeName
      * @param array             $context
+     * @param array             $requirements
      *
      * @return Operation
      */
@@ -71,9 +74,10 @@ class OperationFactory
         $path = null,
         $controller = null,
         $routeName = null,
-        array $context = []
+        array $context = [],
+        $requirements = []
     ) {
-        return $this->createOperation($resource, false, $methods, $path, $controller, $routeName, $context);
+        return $this->createOperation($resource, false, $methods, $path, $controller, $routeName, $context, $requirements);
     }
 
     /**
@@ -86,6 +90,7 @@ class OperationFactory
      * @param string|null       $controller
      * @param string|null       $routeName
      * @param array             $context
+     * @param array             $requirements
      *
      * @return Operation
      */
@@ -96,7 +101,8 @@ class OperationFactory
         $path = null,
         $controller = null,
         $routeName = null,
-        array $context = []
+        array $context = [],
+        $requirements = []
     ) {
         $shortName = $resource->getShortName();
 
@@ -143,7 +149,7 @@ class OperationFactory
                     '_controller' => $controller,
                     '_resource' => $shortName,
                 ],
-                [],
+                $requirements,
                 [],
                 '',
                 [],

--- a/Api/Resource.php
+++ b/Api/Resource.php
@@ -20,7 +20,7 @@ use Dunglas\ApiBundle\Exception\InvalidArgumentException;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-class Resource implements ResourceInterface
+class Resource implements RoutedResourceInterface
 {
     /**
      * @var string
@@ -54,6 +54,14 @@ class Resource implements ResourceInterface
      * @var string|null
      */
     private $shortName;
+    /**
+     * @var string|null
+     */
+    private $itemRouteName;
+    /**
+     * @var string|null
+     */
+    private $collectionRouteName;
 
     /**
      * @param string $entityClass
@@ -226,5 +234,37 @@ class Resource implements ResourceInterface
     public function getShortName()
     {
         return $this->shortName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItemRouteName()
+    {
+        return $this->itemRouteName;
+    }
+
+    /**
+     * @param string|null $itemRouteName
+     */
+    public function setItemRouteName($itemRouteName)
+    {
+        $this->itemRouteName = $itemRouteName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCollectionRouteName()
+    {
+        return $this->collectionRouteName;
+    }
+
+    /**
+     * @param string|null $collectionRouteName
+     */
+    public function setCollectionRouteName($collectionRouteName)
+    {
+        $this->collectionRouteName = $collectionRouteName;
     }
 }

--- a/Api/RoutedResourceInterface.php
+++ b/Api/RoutedResourceInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the DunglasApiBundle package.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Dunglas\ApiBundle\Api;
+
+/**
+ * Class representing an API resource able to specify its item and collection route name.
+ *
+ * @author Jérémy Hubert <jeremy@tofusteak.fr>
+ */
+interface RoutedResourceInterface extends ResourceInterface
+{
+    /**
+     * Gets the item route name of the resource (for @id generation).
+     *
+     * @return string|null
+     */
+    public function getItemRouteName();
+
+    /**
+     * Gets the collection route name of the resource (for @id generation).
+     *
+     * @return string|null
+     */
+    public function getCollectionRouteName();
+}

--- a/Tests/Api/Operation/OperationFactoryTest.php
+++ b/Tests/Api/Operation/OperationFactoryTest.php
@@ -48,17 +48,18 @@ class OperationFactoryTest extends \PHPUnit_Framework_TestCase
     public function testCreateCollectionOperationWithAllParameters()
     {
         $operation = $this->operationFactory->createCollectionOperation(
-            $this->resource, ['GET', 'HEAD'], '/bar', 'AppBundle:Test:cget', 'baz', ['kevin' => 'dunglas']
+            $this->resource, ['GET', 'HEAD'], '/bar/{baz}', 'AppBundle:Test:cget', 'qux', ['kevin' => 'dunglas'], ['baz' => '\d']
         );
 
-        $this->assertEquals('/bar', $operation->getRoute()->getPath());
+        $this->assertEquals('/bar/{baz}', $operation->getRoute()->getPath());
         $this->assertEquals(['GET', 'HEAD'], $operation->getRoute()->getMethods());
+        $this->assertArrayHasKey('baz', $operation->getRoute()->getRequirements());
 
         $defaults = $operation->getRoute()->getDefaults();
         $this->assertEquals('AppBundle:Test:cget', $defaults['_controller']);
         $this->assertEquals('Foo', $defaults['_resource']);
 
-        $this->assertEquals('baz', $operation->getRouteName());
+        $this->assertEquals('qux', $operation->getRouteName());
         $this->assertEquals(['kevin' => 'dunglas'], $operation->getContext());
     }
 
@@ -80,11 +81,12 @@ class OperationFactoryTest extends \PHPUnit_Framework_TestCase
     public function testCreateItemOperationWithAllParameters()
     {
         $operation = $this->operationFactory->createItemOperation(
-            $this->resource, ['GET', 'HEAD'], '/bar/{id}', 'AppBundle:Test:cget', 'baz', ['kevin' => 'dunglas']
+            $this->resource, ['GET', 'HEAD'], '/bar/{id}', 'AppBundle:Test:cget', 'baz', ['kevin' => 'dunglas'], ['id' => '\d']
         );
 
         $this->assertEquals('/bar/{id}', $operation->getRoute()->getPath());
         $this->assertEquals(['GET', 'HEAD'], $operation->getRoute()->getMethods());
+        $this->assertArrayHasKey('id', $operation->getRoute()->getRequirements());
 
         $defaults = $operation->getRoute()->getDefaults();
         $this->assertEquals('AppBundle:Test:cget', $defaults['_controller']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Unable  to test because base tests fails, but this is working as expected in my project.

This PR allows to define route requirements to custom operations : 

```yml
    resource.person.item_operation.get_me:
        class:   "Dunglas\ApiBundle\Api\Operation\Operation"
        public:  false
        factory: [ "@api.operation_factory", "createItemOperation" ]
        arguments:
            -    "@resource.person"       # Resource
            -    [ "GET" ]                # Methods
            -    "/people/{id}"           # Path
            -    "AppBundle:Person:getMe" # Controller
            -    "api_people_get_me"      # Route name
            -    { id: "me|\d" }          # Requirements
```

Also, when you had to `GET` operations for a same resource `item`, the `@id` attribute was using the first operation given to `initItemOperation`, which caused routing conflict regarding the following configuration. That's why I added a method to define the default route name to use for normalization of items `@id`

```yml
    resource.person.item_operation.get:
        class:     "Dunglas\ApiBundle\Api\Operation\Operation"
        public:    false
        factory:   [ "@api.operation_factory", "createItemOperation" ]
        arguments: [ "@resource.person", "GET" ]

    resource.person.item_operation.get_me:
        class:   "Dunglas\ApiBundle\Api\Operation\Operation"
        public:  false
        factory: [ "@api.operation_factory", "createItemOperation" ]
        arguments:
            -    "@resource.person"       # Resource
            -    [ "GET" ]                # Methods
            -    "/people/me"             # Path
            -    "AppBundle:Person:getMe" # Controller
            -    "api_people_get_me"      # Route name
            -    []                       # Requirements

    resource.person:
        parent:    "api.resource"
        arguments: [ "AppBundle\\Entity\\Person" ]
        calls:
            -      method:    "initItemOperations"
                   arguments: [ [ "@resource.person.item_operation.get_me", "@resource.person.item_operation.get", "@resource.person.item_operation.put" ] ]
            -      method:    "setItemRouteName"
                   arguments: [ "api_people_get" ]
        tags:      [ { name: "api.resource" } ]
```

It also works with collection base route name : 

```yml
            -      method:    "setCollectionRouteName"
                   arguments: [ "api_people_custom_cget" ]
```