### PR TITLE
[RFR] Fixing date filter to not consider empty string as a current date

### DIFF
--- a/Doctrine/Orm/Filter/DateFilter.php
+++ b/Doctrine/Orm/Filter/DateFilter.php
@@ -76,7 +76,7 @@ class DateFilter extends AbstractFilter
 
             $nullManagement = isset($this->properties[$property]) ? $this->properties[$property] : null;
 
-            if (isset($values[self::PARAMETER_BEFORE])) {
+            if (!empty($values[self::PARAMETER_BEFORE])) {
                 $this->addWhere(
                     $queryBuilder,
                     $alias,
@@ -87,7 +87,7 @@ class DateFilter extends AbstractFilter
                 );
             }
 
-            if (isset($values[self::PARAMETER_AFTER])) {
+            if (!empty($values[self::PARAMETER_AFTER])) {
                 $this->addWhere(
                     $queryBuilder,
                     $alias,

--- a/features/doctrine/date-filter.feature
+++ b/features/doctrine/date-filter.feature
@@ -226,3 +226,71 @@ Feature: Order filter on collections
       }
     }
     """
+
+  @createSchema
+  @dropSchema
+  Scenario: Search for entities within a range
+    Given there is "2" dummy objects with dummyDate
+    When I send a "GET" request to "/dummies?dummyDate[after]="
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json"
+    And the JSON node "hydra:totalItems" should be equal to "2"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Dummy$"},
+        "@id": {"pattern": "^/dummies\\?dummyDate\\[after\\]=$"},
+        "@type": {"pattern": "^hydra:PagedCollection$"},
+        "hydra:totalItems": {"type":"number"},
+        "hydra:member": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "@id": {
+                "oneOf": [
+                  {"pattern": "^/dummies/1$"},
+                  {"pattern": "^/dummies/2$"}
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+    When I send a "GET" request to "/dummies?dummyDate[before]="
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json"
+    And the JSON node "hydra:totalItems" should be equal to "2"
+    And the JSON should be valid according to this schema:
+    """
+    {
+      "type": "object",
+      "properties": {
+        "@context": {"pattern": "^/contexts/Dummy$"},
+        "@id": {"pattern": "^/dummies\\?dummyDate\\[before\\]=$"},
+        "@type": {"pattern": "^hydra:PagedCollection$"},
+        "hydra:totalItems": {"type":"number"},
+        "hydra:member": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "@id": {
+                "oneOf": [
+                  {"pattern": "^/dummies/1$"},
+                  {"pattern": "^/dummies/2$"}
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+    """


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | may be
| New feature?  | no
| BC breaks?    | may be
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT

Actually when we use DateFilter, if we send an empty parameter `property[before]=`, doctrine will convert it to current date (`new \Datetime('')`). This is annoying for a filtering behaviour, empty params should be ignored. 

If we want use currentDate in DateFilter, we can use `now` string.

