### PR TITLE
Fix a bug when a JSON key is empty

### DIFF
--- a/JsonLd/Serializer/ItemNormalizer.php
+++ b/JsonLd/Serializer/ItemNormalizer.php
@@ -187,9 +187,7 @@ class ItemNormalizer extends AbstractNormalizer
 
         $resource = $this->guessResource($data, $context, true);
         $normalizedData = $this->prepareForDenormalization($data);
-
         $context = $this->createContext($resource, $context);
-
         $attributesMetadata = $this->getMetadata($resource, $context)->getAttributes();
 
         $allowedAttributes = [];
@@ -228,11 +226,6 @@ class ItemNormalizer extends AbstractNormalizer
         );
 
         foreach ($normalizedData as $attributeName => $attributeValue) {
-            // Ignore JSON-LD special attributes
-            if ('@' === $attributeName[0]) {
-                continue;
-            }
-
             if ($this->nameConverter) {
                 $attributeName = $this->nameConverter->denormalize($attributeName);
             }

--- a/features/invalid_data.feature
+++ b/features/invalid_data.feature
@@ -46,6 +46,28 @@ Feature: Handle properly invalid data submitted to the API
     And the response should be in JSON
     And the header "Content-Type" should be equal to "application/ld+json"
 
+  Scenario: Send a document with an integer as key (invalid JSON)
+    When I send a "POST" request to "/dummies" with body:
+    """
+    {
+      0: "bar"
+    }
+    """
+    Then the response status code should be 400
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json"
+
+  Scenario: Send a document with an empty as key (valid JSON)
+    When I send a "POST" request to "/dummies" with body:
+    """
+    {
+      "": "bar"
+    }
+    """
+    Then the response status code should be 400
+    And the response should be in JSON
+    And the header "Content-Type" should be equal to "application/ld+json"
+
   @dropSchema
   Scenario: Send non-array data when an array is expected
     When I send a "POST" request to "/dummies" with body:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #394, #393 
| License       | MIT
| Doc PR        | n/a

@dylanjacob, can you try if this PR fix your problem? If it's not the case, can you add a failing test because I wasn't able to reproduce for now.